### PR TITLE
feat: 目安表示モードを追加

### DIFF
--- a/AgentLimits/App/AgentLimitsApp.swift
+++ b/AgentLimits/App/AgentLimitsApp.swift
@@ -410,8 +410,6 @@ private struct MenuBarContentView: View {
             Button { displayMode = .remaining } label: {
                 CheckmarkLabel("menu.displayMode.remaining".localized(), isSelected: displayMode == .remaining)
             }
-            Button { displayMode = .ideal } label: {
-                CheckmarkLabel("menu.displayMode.ideal".localized(), isSelected: displayMode == .ideal)
             }
             Button { displayMode = .usedWithIdeal } label: {
                 CheckmarkLabel("menu.displayMode.usedWithIdeal".localized(), isSelected: displayMode == .usedWithIdeal)

--- a/AgentLimits/App/AgentLimitsApp.swift
+++ b/AgentLimits/App/AgentLimitsApp.swift
@@ -281,19 +281,44 @@ private struct MenuBarPercentLineView: View {
     }
 
     private func formatPercentText(_ window: UsageWindow?) -> String {
-        let percent = window.map { displayMode.displayPercent(from: $0.usedPercent) }
+        guard let window else {
+            return UsagePercentFormatter.formatPercentText(nil)
+        }
+        
+        if displayMode == .usedWithIdeal {
+            let usedPercent = Int(window.usedPercent.rounded())
+            if let idealPercent = window.calculateIdealUsagePercent() {
+                let idealInt = Int(idealPercent.rounded())
+                return "\(usedPercent)(\(idealInt))%"
+            } else {
+                return "\(usedPercent)%"
+            }
+        }
+        
+        let percent = displayMode.displayPercent(from: window.usedPercent, window: window)
         return UsagePercentFormatter.formatPercentText(percent)
     }
 
     private func resolveStatusColor(_ window: UsageWindow?, windowKind: UsageWindowKind) -> Color {
         guard let window else { return .secondary }
-        let thresholds = UsageStatusThresholdStore.loadThresholds(for: provider, windowKind: windowKind)
-        let level = UsageStatusLevelResolver.level(
-            for: window.usedPercent,
-            isRemainingMode: false,
-            warningThreshold: thresholds.warningPercent,
-            dangerThreshold: thresholds.dangerPercent
-        )
+        let level: UsageStatusLevel
+        if displayMode == .ideal || displayMode == .usedWithIdeal {
+            guard let idealPercent = window.calculateIdealUsagePercent() else {
+                return .secondary
+            }
+            level = UsageStatusLevelResolver.levelForIdealMode(
+                usedPercent: window.usedPercent,
+                idealPercent: idealPercent
+            )
+        } else {
+            let thresholds = UsageStatusThresholdStore.loadThresholds(for: provider, windowKind: windowKind)
+            level = UsageStatusLevelResolver.level(
+                for: window.usedPercent,
+                isRemainingMode: false,
+                warningThreshold: thresholds.warningPercent,
+                dangerThreshold: thresholds.dangerPercent
+            )
+        }
         switch level {
         case .green:
             return resolveStoredColor(from: statusGreenHex, defaultColor: .green)
@@ -384,6 +409,12 @@ private struct MenuBarContentView: View {
             }
             Button { displayMode = .remaining } label: {
                 CheckmarkLabel("menu.displayMode.remaining".localized(), isSelected: displayMode == .remaining)
+            }
+            Button { displayMode = .ideal } label: {
+                CheckmarkLabel("menu.displayMode.ideal".localized(), isSelected: displayMode == .ideal)
+            }
+            Button { displayMode = .usedWithIdeal } label: {
+                CheckmarkLabel("menu.displayMode.usedWithIdeal".localized(), isSelected: displayMode == .usedWithIdeal)
             }
         } label: {
             Label("menu.displayMode".localized(), systemImage: "eye")

--- a/AgentLimits/App/AgentLimitsApp.swift
+++ b/AgentLimits/App/AgentLimitsApp.swift
@@ -308,7 +308,9 @@ private struct MenuBarPercentLineView: View {
             }
             level = UsageStatusLevelResolver.levelForIdealMode(
                 usedPercent: window.usedPercent,
-                idealPercent: idealPercent
+                idealPercent: idealPercent,
+                warningDelta: IdealModeThresholdSettings.loadWarningDelta(),
+                dangerDelta: IdealModeThresholdSettings.loadDangerDelta()
             )
         } else {
             let thresholds = UsageStatusThresholdStore.loadThresholds(for: provider, windowKind: windowKind)

--- a/AgentLimits/App/AgentLimitsApp.swift
+++ b/AgentLimits/App/AgentLimitsApp.swift
@@ -302,7 +302,7 @@ private struct MenuBarPercentLineView: View {
     private func resolveStatusColor(_ window: UsageWindow?, windowKind: UsageWindowKind) -> Color {
         guard let window else { return .secondary }
         let level: UsageStatusLevel
-        if displayMode == .ideal || displayMode == .usedWithIdeal {
+        if displayMode == .usedWithIdeal {
             guard let idealPercent = window.calculateIdealUsagePercent() else {
                 return .secondary
             }
@@ -409,7 +409,6 @@ private struct MenuBarContentView: View {
             }
             Button { displayMode = .remaining } label: {
                 CheckmarkLabel("menu.displayMode.remaining".localized(), isSelected: displayMode == .remaining)
-            }
             }
             Button { displayMode = .usedWithIdeal } label: {
                 CheckmarkLabel("menu.displayMode.usedWithIdeal".localized(), isSelected: displayMode == .usedWithIdeal)

--- a/AgentLimits/Scripts/agentlimits_statusline_claude.sh
+++ b/AgentLimits/Scripts/agentlimits_statusline_claude.sh
@@ -32,6 +32,10 @@ DEFAULT_COLOR_RED="#FF0000"
 DEFAULT_WARNING_THRESHOLD=70
 DEFAULT_DANGER_THRESHOLD=90
 
+
+# Default ideal mode thresholds (excess percentage)
+DEFAULT_IDEAL_WARNING_DELTA=0
+DEFAULT_IDEAL_DANGER_DELTA=10
 # Debug flag (prints detailed settings and parsed values)
 DEBUG=false
 
@@ -106,6 +110,25 @@ get_status_level() {
     if [[ $used_percent -ge $danger_threshold ]]; then
         echo "red"
     elif [[ $used_percent -ge $warning_threshold ]]; then
+        echo "orange"
+    else
+        echo "green"
+    fi
+}
+
+# Determine status level for ideal mode (comparison-based)
+# Returns: "green", "orange", or "red"
+get_ideal_status_level() {
+    local used_percent="$1"
+    local ideal_percent="$2"
+    local warning_delta="$3"
+    local danger_delta="$4"
+    
+    local diff=$((used_percent - ideal_percent))
+    
+    if [[ $diff -ge $danger_delta ]]; then
+        echo "red"
+    elif [[ $diff -gt $warning_delta ]]; then
         echo "orange"
     else
         echo "green"
@@ -221,6 +244,8 @@ primary_percent=$(echo "$json_data" | jq -r '.primaryWindow.usedPercent // empty
 primary_reset_at=$(echo "$json_data" | jq -r '.primaryWindow.resetAt // empty')
 secondary_percent=$(echo "$json_data" | jq -r '.secondaryWindow.usedPercent // empty')
 secondary_reset_at=$(echo "$json_data" | jq -r '.secondaryWindow.resetAt // empty')
+primary_window_seconds=$(echo "$json_data" | jq -r '.primaryWindow.limitWindowSeconds // 18000')
+secondary_window_seconds=$(echo "$json_data" | jq -r '.secondaryWindow.limitWindowSeconds // 604800')
 fetched_at=$(echo "$json_data" | jq -r '.fetchedAt // empty')
 snapshot_display_mode=$(echo "$json_data" | jq -r '.displayMode // empty')
 
@@ -261,6 +286,49 @@ convert_iso8601_to_local() {
 }
 
 # Format updated time (absolute)
+# Calculate ideal usage percentage based on elapsed time
+# Returns: integer percentage (0-100)
+calculate_ideal_percent() {
+    local reset_at_iso="$1"
+    local window_seconds="$2"
+    
+    # Convert reset_at to Unix timestamp
+    local clean_date
+    clean_date=$(echo "$reset_at_iso" | sed 's/.[0-9]*Z$/Z/' | sed 's/Z$/+0000/')
+    local reset_ts
+    reset_ts=$(date -j -f "%Y-%m-%dT%H:%M:%S%z" "$clean_date" +"%s" 2>/dev/null)
+    
+    if [[ -z "$reset_ts" || ! "$reset_ts" =~ ^[0-9]+$ ]]; then
+        echo "50"  # Fallback to 50%
+        return
+    fi
+    
+    # Calculate window start (reset - window_seconds)
+    local window_start=$((reset_ts - window_seconds))
+    local now_ts
+    now_ts=$(date +"%s")
+    
+    # Calculate elapsed time
+    local elapsed=$((now_ts - window_start))
+    
+    # Calculate ideal percentage
+    if [[ $window_seconds -le 0 ]]; then
+        echo "50"
+        return
+    fi
+    
+    local ideal_percent=$((elapsed * 100 / window_seconds))
+    
+    # Clamp to 0-100
+    if [[ $ideal_percent -lt 0 ]]; then
+        ideal_percent=0
+    elif [[ $ideal_percent -gt 100 ]]; then
+        ideal_percent=100
+    fi
+    
+    echo "$ideal_percent"
+}
+
 format_updated_at() {
     local fetched_iso="$1"
     local updated_time
@@ -291,6 +359,10 @@ PRIMARY_DANGER=$(read_threshold "usage_color_threshold_danger_claudeCode_primary
 SECONDARY_WARNING=$(read_threshold "usage_color_threshold_warning_claudeCode_secondary" "$DEFAULT_WARNING_THRESHOLD")
 SECONDARY_DANGER=$(read_threshold "usage_color_threshold_danger_claudeCode_secondary" "$DEFAULT_DANGER_THRESHOLD")
 
+# Read ideal mode thresholds
+IDEAL_WARNING_DELTA=$(read_threshold "ideal_mode_warning_delta" "$DEFAULT_IDEAL_WARNING_DELTA")
+IDEAL_DANGER_DELTA=$(read_threshold "ideal_mode_danger_delta" "$DEFAULT_IDEAL_DANGER_DELTA")
+
 # Read color settings
 COLOR_GREEN=$(read_color "usage_color_green" "$DEFAULT_COLOR_GREEN")
 COLOR_ORANGE=$(read_color "usage_color_orange" "$DEFAULT_COLOR_ORANGE")
@@ -299,6 +371,7 @@ COLOR_RED=$(read_color "usage_color_red" "$DEFAULT_COLOR_RED")
 debug_log "thresholds.primary warning=${PRIMARY_WARNING} danger=${PRIMARY_DANGER}"
 debug_log "thresholds.secondary warning=${SECONDARY_WARNING} danger=${SECONDARY_DANGER}"
 debug_log "colors green=${COLOR_GREEN} orange=${COLOR_ORANGE} red=${COLOR_RED}"
+debug_log "ideal_thresholds warning_delta=${IDEAL_WARNING_DELTA} danger_delta=${IDEAL_DANGER_DELTA}"
 
 # Convert hex colors to ANSI escape sequences
 ANSI_GREEN=$(hex_to_ansi "$COLOR_GREEN")
@@ -306,8 +379,22 @@ ANSI_ORANGE=$(hex_to_ansi "$COLOR_ORANGE")
 ANSI_RED=$(hex_to_ansi "$COLOR_RED")
 
 # Determine status levels based on USED percentages (before display mode conversion)
-primary_status=$(get_status_level "$primary_used_int" "$PRIMARY_WARNING" "$PRIMARY_DANGER")
-secondary_status=$(get_status_level "$secondary_used_int" "$SECONDARY_WARNING" "$SECONDARY_DANGER")
+# For usedWithIdeal mode, use comparison-based logic
+if [[ "$APP_DISPLAY_MODE" == "usedWithIdeal" ]]; then
+    # Calculate ideal percentages
+    primary_ideal_int=$(calculate_ideal_percent "$primary_reset_at" "$primary_window_seconds")
+    secondary_ideal_int=$(calculate_ideal_percent "$secondary_reset_at" "$secondary_window_seconds")
+    
+    # Use ideal mode status calculation
+    primary_status=$(get_ideal_status_level "$primary_used_int" "$primary_ideal_int" "$IDEAL_WARNING_DELTA" "$IDEAL_DANGER_DELTA")
+    secondary_status=$(get_ideal_status_level "$secondary_used_int" "$secondary_ideal_int" "$IDEAL_WARNING_DELTA" "$IDEAL_DANGER_DELTA")
+    
+    debug_log "ideal_mode.primary used=${primary_used_int} ideal=${primary_ideal_int} status=${primary_status}"
+    debug_log "ideal_mode.secondary used=${secondary_used_int} ideal=${secondary_ideal_int} status=${secondary_status}"
+else
+    primary_status=$(get_status_level "$primary_used_int" "$PRIMARY_WARNING" "$PRIMARY_DANGER")
+    secondary_status=$(get_status_level "$secondary_used_int" "$SECONDARY_WARNING" "$SECONDARY_DANGER")
+fi
 
 # Apply display mode conversion for display
 if [[ "$DISPLAY_MODE" == "remaining" ]]; then
@@ -334,5 +421,15 @@ get_status_color() {
 primary_color=$(get_status_color "$primary_status")
 secondary_color=$(get_status_color "$secondary_status")
 
+# Format percentage text based on display mode
+if [[ "$APP_DISPLAY_MODE" == "usedWithIdeal" ]]; then
+    # Show used(ideal)% format
+    primary_text="${primary_used_int}(${primary_ideal_int})%"
+    secondary_text="${secondary_used_int}(${secondary_ideal_int})%"
+else
+    primary_text="${primary_percent_int}%"
+    secondary_text="${secondary_percent_int}%"
+fi
+
 # Output formatted string with colored percentages and gray reset times/updated time
-echo -e "🕔 5h: ${primary_color}${primary_percent_int}%${RESET_COLOR} ${GRAY}(${L_RESET} ${primary_reset_time})${RESET_COLOR} / 📅 1w: ${secondary_color}${secondary_percent_int}%${RESET_COLOR} ${GRAY}(${L_RESET} ${secondary_reset_time})${RESET_COLOR} - ${GRAY}${updated_text}${RESET_COLOR}"
+echo -e "🕔 5h: ${primary_color}${primary_text}${RESET_COLOR} ${GRAY}(${L_RESET} ${primary_reset_time})${RESET_COLOR} / 📅 1w: ${secondary_color}${secondary_text}${RESET_COLOR} ${GRAY}(${L_RESET} ${secondary_reset_time})${RESET_COLOR} - ${GRAY}${updated_text}${RESET_COLOR}"

--- a/AgentLimits/Usage/AppUsageModels.swift
+++ b/AgentLimits/Usage/AppUsageModels.swift
@@ -17,7 +17,6 @@ enum UserDefaultsKeys {
 enum UsageDisplayMode: String, Codable, CaseIterable, Identifiable {
     case used
     case remaining
-    case ideal
     case usedWithIdeal
 
     var id: String { rawValue }
@@ -29,8 +28,6 @@ enum UsageDisplayMode: String, Codable, CaseIterable, Identifiable {
             return "displayMode.used".localized()
         case .remaining:
             return "displayMode.remaining".localized()
-        case .ideal:
-            return "displayMode.ideal".localized()
         case .usedWithIdeal:
             return "displayMode.usedWithIdeal".localized()
         }
@@ -48,8 +45,6 @@ enum UsageDisplayMode: String, Codable, CaseIterable, Identifiable {
             return max(0, min(100, usedPercent))
         case .remaining:
             return max(0, min(100, 100 - usedPercent))
-        case .ideal:
-            return window?.calculateIdealUsagePercent() ?? 0
         }
     }
 
@@ -58,10 +53,10 @@ enum UsageDisplayMode: String, Codable, CaseIterable, Identifiable {
         let value: Double
         if sourceMode == self {
             value = percent
-        } else if self == .ideal || self == .usedWithIdeal {
+        } else if self == .usedWithIdeal {
             // Ideal mode doesn't convert from other modes
             value = percent
-        } else if sourceMode == .ideal || sourceMode == .usedWithIdeal {
+        } else if sourceMode == .usedWithIdeal {
             // Converting from ideal to used/remaining doesn't make sense
             value = percent
         } else {
@@ -79,8 +74,6 @@ extension UsageDisplayMode {
             return .used
         case .remaining:
             return .remaining
-        case .ideal:
-            return .ideal
         case .usedWithIdeal:
             return .usedWithIdeal
         }
@@ -95,8 +88,6 @@ extension UsageDisplayModeRaw {
             return .used
         case .remaining:
             return .remaining
-        case .ideal:
-            return .ideal
         case .usedWithIdeal:
             return .usedWithIdeal
         }

--- a/AgentLimits/Usage/ContentView.swift
+++ b/AgentLimits/Usage/ContentView.swift
@@ -384,7 +384,7 @@ private struct UsageWindowRow: View {
     }
 
     private var windowPercentText: String {
-        let percent = window.map { displayMode.displayPercent(from: $0.usedPercent) }
+        let percent = window.map { displayMode.displayPercent(from: $0.usedPercent, window: $0) }
         return UsagePercentFormatter.formatPercentText(percent)
     }
 }

--- a/AgentLimits/de.lproj/Localizable.strings
+++ b/AgentLimits/de.lproj/Localizable.strings
@@ -9,6 +9,8 @@
 "menu.displayMode" = "Anzeigemodus";
 "menu.displayMode.used" = "Nutzungsrate";
 "menu.displayMode.remaining" = "Verbleibende Rate";
+"menu.displayMode.ideal" = "Richtwert";
+"menu.displayMode.usedWithIdeal" = "Nutzung + Richtwert";
 "menu.about" = "Über AgentLimits";
 "menu.quit" = "Beenden";
 "menu.language" = "Sprache";
@@ -43,6 +45,8 @@
 /* Display Mode */
 "displayMode.used" = "Nutzungsrate";
 "displayMode.remaining" = "Verbleibende Rate";
+"displayMode.ideal" = "Richtwert";
+"displayMode.usedWithIdeal" = "Nutzung + Richtwert";
 
 /* Status */
 "status.notFetched" = "Nicht abgerufen";

--- a/AgentLimits/de.lproj/Localizable.strings
+++ b/AgentLimits/de.lproj/Localizable.strings
@@ -9,7 +9,6 @@
 "menu.displayMode" = "Anzeigemodus";
 "menu.displayMode.used" = "Nutzungsrate";
 "menu.displayMode.remaining" = "Verbleibende Rate";
-"menu.displayMode.ideal" = "Richtwert";
 "menu.displayMode.usedWithIdeal" = "Nutzung + Richtwert";
 "menu.about" = "Über AgentLimits";
 "menu.quit" = "Beenden";
@@ -45,7 +44,6 @@
 /* Display Mode */
 "displayMode.used" = "Nutzungsrate";
 "displayMode.remaining" = "Verbleibende Rate";
-"displayMode.ideal" = "Richtwert";
 "displayMode.usedWithIdeal" = "Nutzung + Richtwert";
 
 /* Status */

--- a/AgentLimits/de.lproj/Localizable.strings
+++ b/AgentLimits/de.lproj/Localizable.strings
@@ -183,3 +183,9 @@
 "widgetTapAction.openWebsite" = "Website öffnen";
 "widgetTapAction.refreshData" = "Daten aktualisieren";
 "widgetTapAction.note" = "Wählen Sie, was beim Tippen auf ein Widget passiert";
+
+/* Ideal Mode Thresholds */
+"notification.idealModeThresholds" = "Guideline Mode Thresholds";
+"notification.idealModeThresholds.description" = "Color thresholds when exceeding guideline";
+"notification.idealModeThresholds.warning" = "Warning (Orange)";
+"notification.idealModeThresholds.danger" = "Danger (Red)";

--- a/AgentLimits/en.lproj/Localizable.strings
+++ b/AgentLimits/en.lproj/Localizable.strings
@@ -9,7 +9,6 @@
 "menu.displayMode" = "Display Mode";
 "menu.displayMode.used" = "Usage rate";
 "menu.displayMode.remaining" = "Remaining rate";
-"menu.displayMode.ideal" = "Guideline";
 "menu.displayMode.usedWithIdeal" = "Usage + Guideline";
 "menu.about" = "About AgentLimits";
 "menu.quit" = "Quit";
@@ -45,7 +44,6 @@
 /* Display Mode */
 "displayMode.used" = "Usage rate";
 "displayMode.remaining" = "Remaining rate";
-"displayMode.ideal" = "Guideline";
 "displayMode.usedWithIdeal" = "Usage + Guideline";
 
 /* Status */

--- a/AgentLimits/en.lproj/Localizable.strings
+++ b/AgentLimits/en.lproj/Localizable.strings
@@ -9,6 +9,8 @@
 "menu.displayMode" = "Display Mode";
 "menu.displayMode.used" = "Usage rate";
 "menu.displayMode.remaining" = "Remaining rate";
+"menu.displayMode.ideal" = "Guideline";
+"menu.displayMode.usedWithIdeal" = "Usage + Guideline";
 "menu.about" = "About AgentLimits";
 "menu.quit" = "Quit";
 "menu.language" = "Language";
@@ -43,6 +45,8 @@
 /* Display Mode */
 "displayMode.used" = "Usage rate";
 "displayMode.remaining" = "Remaining rate";
+"displayMode.ideal" = "Guideline";
+"displayMode.usedWithIdeal" = "Usage + Guideline";
 
 /* Status */
 "status.notFetched" = "Not fetched";

--- a/AgentLimits/en.lproj/Localizable.strings
+++ b/AgentLimits/en.lproj/Localizable.strings
@@ -183,3 +183,9 @@
 "widgetTapAction.openWebsite" = "Open Website";
 "widgetTapAction.refreshData" = "Refresh Data";
 "widgetTapAction.note" = "Choose what happens when you tap a widget";
+
+/* Ideal Mode Thresholds */
+"notification.idealModeThresholds" = "Guideline Mode Thresholds";
+"notification.idealModeThresholds.description" = "Color thresholds when exceeding guideline in Used + Guideline mode";
+"notification.idealModeThresholds.warning" = "Warning (Orange)";
+"notification.idealModeThresholds.danger" = "Danger (Red)";

--- a/AgentLimits/es.lproj/Localizable.strings
+++ b/AgentLimits/es.lproj/Localizable.strings
@@ -183,3 +183,9 @@
 "widgetTapAction.openWebsite" = "Abrir sitio web";
 "widgetTapAction.refreshData" = "Actualizar datos";
 "widgetTapAction.note" = "Elige lo que ocurre al tocar un widget";
+
+/* Ideal Mode Thresholds */
+"notification.idealModeThresholds" = "Guideline Mode Thresholds";
+"notification.idealModeThresholds.description" = "Color thresholds when exceeding guideline";
+"notification.idealModeThresholds.warning" = "Warning (Orange)";
+"notification.idealModeThresholds.danger" = "Danger (Red)";

--- a/AgentLimits/es.lproj/Localizable.strings
+++ b/AgentLimits/es.lproj/Localizable.strings
@@ -9,7 +9,6 @@
 "menu.displayMode" = "Modo de visualización";
 "menu.displayMode.used" = "Tasa de uso";
 "menu.displayMode.remaining" = "Tasa restante";
-"menu.displayMode.ideal" = "Referencia";
 "menu.displayMode.usedWithIdeal" = "Uso + Referencia";
 "menu.about" = "Acerca de AgentLimits";
 "menu.quit" = "Salir";
@@ -45,7 +44,6 @@
 /* Display Mode */
 "displayMode.used" = "Tasa de uso";
 "displayMode.remaining" = "Tasa restante";
-"displayMode.ideal" = "Referencia";
 "displayMode.usedWithIdeal" = "Uso + Referencia";
 
 /* Status */

--- a/AgentLimits/es.lproj/Localizable.strings
+++ b/AgentLimits/es.lproj/Localizable.strings
@@ -9,6 +9,8 @@
 "menu.displayMode" = "Modo de visualización";
 "menu.displayMode.used" = "Tasa de uso";
 "menu.displayMode.remaining" = "Tasa restante";
+"menu.displayMode.ideal" = "Referencia";
+"menu.displayMode.usedWithIdeal" = "Uso + Referencia";
 "menu.about" = "Acerca de AgentLimits";
 "menu.quit" = "Salir";
 "menu.language" = "Idioma";
@@ -43,6 +45,8 @@
 /* Display Mode */
 "displayMode.used" = "Tasa de uso";
 "displayMode.remaining" = "Tasa restante";
+"displayMode.ideal" = "Referencia";
+"displayMode.usedWithIdeal" = "Uso + Referencia";
 
 /* Status */
 "status.notFetched" = "No se obtuvo";

--- a/AgentLimits/fr.lproj/Localizable.strings
+++ b/AgentLimits/fr.lproj/Localizable.strings
@@ -183,3 +183,9 @@
 "widgetTapAction.openWebsite" = "Ouvrir le site web";
 "widgetTapAction.refreshData" = "Actualiser les données";
 "widgetTapAction.note" = "Choisissez l’action au toucher d’un widget";
+
+/* Ideal Mode Thresholds */
+"notification.idealModeThresholds" = "Guideline Mode Thresholds";
+"notification.idealModeThresholds.description" = "Color thresholds when exceeding guideline";
+"notification.idealModeThresholds.warning" = "Warning (Orange)";
+"notification.idealModeThresholds.danger" = "Danger (Red)";

--- a/AgentLimits/fr.lproj/Localizable.strings
+++ b/AgentLimits/fr.lproj/Localizable.strings
@@ -10,7 +10,7 @@
 "menu.displayMode.used" = "Taux d’utilisation";
 "menu.displayMode.remaining" = "Taux restant";
 "menu.displayMode.ideal" = "Repère";
-"menu.displayMode.usedWithIdeal" = "Utilisation + Repèree";
+"menu.displayMode.usedWithIdeal" = "Utilisation + Repère";
 "menu.about" = "À propos d’AgentLimits";
 "menu.quit" = "Quitter";
 "menu.language" = "Langue";
@@ -46,7 +46,7 @@
 "displayMode.used" = "Taux d’utilisation";
 "displayMode.remaining" = "Taux restant";
 "displayMode.ideal" = "Repère";
-"displayMode.usedWithIdeal" = "Utilisation + Repèree";
+"displayMode.usedWithIdeal" = "Utilisation + Repère";
 
 /* Status */
 "status.notFetched" = "Non récupéré";

--- a/AgentLimits/fr.lproj/Localizable.strings
+++ b/AgentLimits/fr.lproj/Localizable.strings
@@ -9,6 +9,8 @@
 "menu.displayMode" = "Mode d’affichage";
 "menu.displayMode.used" = "Taux d’utilisation";
 "menu.displayMode.remaining" = "Taux restant";
+"menu.displayMode.ideal" = "Repère";
+"menu.displayMode.usedWithIdeal" = "Utilisation + Repèree";
 "menu.about" = "À propos d’AgentLimits";
 "menu.quit" = "Quitter";
 "menu.language" = "Langue";
@@ -43,6 +45,8 @@
 /* Display Mode */
 "displayMode.used" = "Taux d’utilisation";
 "displayMode.remaining" = "Taux restant";
+"displayMode.ideal" = "Repère";
+"displayMode.usedWithIdeal" = "Utilisation + Repèree";
 
 /* Status */
 "status.notFetched" = "Non récupéré";

--- a/AgentLimits/fr.lproj/Localizable.strings
+++ b/AgentLimits/fr.lproj/Localizable.strings
@@ -9,7 +9,6 @@
 "menu.displayMode" = "Mode d’affichage";
 "menu.displayMode.used" = "Taux d’utilisation";
 "menu.displayMode.remaining" = "Taux restant";
-"menu.displayMode.ideal" = "Repère";
 "menu.displayMode.usedWithIdeal" = "Utilisation + Repère";
 "menu.about" = "À propos d’AgentLimits";
 "menu.quit" = "Quitter";
@@ -45,7 +44,6 @@
 /* Display Mode */
 "displayMode.used" = "Taux d’utilisation";
 "displayMode.remaining" = "Taux restant";
-"displayMode.ideal" = "Repère";
 "displayMode.usedWithIdeal" = "Utilisation + Repère";
 
 /* Status */

--- a/AgentLimits/it.lproj/Localizable.strings
+++ b/AgentLimits/it.lproj/Localizable.strings
@@ -183,3 +183,9 @@
 "widgetTapAction.openWebsite" = "Apri sito web";
 "widgetTapAction.refreshData" = "Aggiorna dati";
 "widgetTapAction.note" = "Scegli cosa succede quando tocchi un widget";
+
+/* Ideal Mode Thresholds */
+"notification.idealModeThresholds" = "Guideline Mode Thresholds";
+"notification.idealModeThresholds.description" = "Color thresholds when exceeding guideline";
+"notification.idealModeThresholds.warning" = "Warning (Orange)";
+"notification.idealModeThresholds.danger" = "Danger (Red)";

--- a/AgentLimits/it.lproj/Localizable.strings
+++ b/AgentLimits/it.lproj/Localizable.strings
@@ -9,7 +9,6 @@
 "menu.displayMode" = "Modalità di visualizzazione";
 "menu.displayMode.used" = "Tasso di utilizzo";
 "menu.displayMode.remaining" = "Tasso rimanente";
-"menu.displayMode.ideal" = "Riferimento";
 "menu.displayMode.usedWithIdeal" = "Utilizzo + Riferimento";
 "menu.about" = "Informazioni su AgentLimits";
 "menu.quit" = "Esci";
@@ -45,7 +44,6 @@
 /* Display Mode */
 "displayMode.used" = "Tasso di utilizzo";
 "displayMode.remaining" = "Tasso rimanente";
-"displayMode.ideal" = "Riferimento";
 "displayMode.usedWithIdeal" = "Utilizzo + Riferimento";
 
 /* Status */

--- a/AgentLimits/it.lproj/Localizable.strings
+++ b/AgentLimits/it.lproj/Localizable.strings
@@ -9,6 +9,8 @@
 "menu.displayMode" = "Modalità di visualizzazione";
 "menu.displayMode.used" = "Tasso di utilizzo";
 "menu.displayMode.remaining" = "Tasso rimanente";
+"menu.displayMode.ideal" = "Riferimento";
+"menu.displayMode.usedWithIdeal" = "Utilizzo + Riferimento";
 "menu.about" = "Informazioni su AgentLimits";
 "menu.quit" = "Esci";
 "menu.language" = "Lingua";
@@ -43,6 +45,8 @@
 /* Display Mode */
 "displayMode.used" = "Tasso di utilizzo";
 "displayMode.remaining" = "Tasso rimanente";
+"displayMode.ideal" = "Riferimento";
+"displayMode.usedWithIdeal" = "Utilizzo + Riferimento";
 
 /* Status */
 "status.notFetched" = "Non recuperato";

--- a/AgentLimits/ja.lproj/Localizable.strings
+++ b/AgentLimits/ja.lproj/Localizable.strings
@@ -9,7 +9,6 @@
 "menu.displayMode" = "表示モード";
 "menu.displayMode.used" = "使用率";
 "menu.displayMode.remaining" = "残り使用率";
-"menu.displayMode.ideal" = "目安";
 "menu.displayMode.usedWithIdeal" = "使用率 + 目安";
 "menu.about" = "AgentLimitsについて";
 "menu.quit" = "終了";
@@ -45,7 +44,6 @@
 /* Display Mode */
 "displayMode.used" = "使用率";
 "displayMode.remaining" = "残り使用率";
-"displayMode.ideal" = "目安";
 "displayMode.usedWithIdeal" = "使用率 + 目安";
 
 /* Status */

--- a/AgentLimits/ja.lproj/Localizable.strings
+++ b/AgentLimits/ja.lproj/Localizable.strings
@@ -183,3 +183,9 @@
 "widgetTapAction.openWebsite" = "Webサイトを開く";
 "widgetTapAction.refreshData" = "データを再取得";
 "widgetTapAction.note" = "ウィジェットをタップしたときの動作を選択します";
+
+/* Ideal Mode Thresholds */
+"notification.idealModeThresholds" = "目安モード閾値";
+"notification.idealModeThresholds.description" = "「使用率+目安」モードで目安を超過した時の色分け閾値";
+"notification.idealModeThresholds.warning" = "警告（オレンジ）";
+"notification.idealModeThresholds.danger" = "危険（赤）";

--- a/AgentLimits/ja.lproj/Localizable.strings
+++ b/AgentLimits/ja.lproj/Localizable.strings
@@ -9,6 +9,8 @@
 "menu.displayMode" = "表示モード";
 "menu.displayMode.used" = "使用率";
 "menu.displayMode.remaining" = "残り使用率";
+"menu.displayMode.ideal" = "目安";
+"menu.displayMode.usedWithIdeal" = "使用率 + 目安";
 "menu.about" = "AgentLimitsについて";
 "menu.quit" = "終了";
 "menu.language" = "言語";
@@ -43,6 +45,8 @@
 /* Display Mode */
 "displayMode.used" = "使用率";
 "displayMode.remaining" = "残り使用率";
+"displayMode.ideal" = "目安";
+"displayMode.usedWithIdeal" = "使用率 + 目安";
 
 /* Status */
 "status.notFetched" = "未取得";

--- a/AgentLimits/ko.lproj/Localizable.strings
+++ b/AgentLimits/ko.lproj/Localizable.strings
@@ -9,7 +9,6 @@
 "menu.displayMode" = "표시 모드";
 "menu.displayMode.used" = "사용률";
 "menu.displayMode.remaining" = "잔여 사용률";
-"menu.displayMode.ideal" = "기준";
 "menu.displayMode.usedWithIdeal" = "사용률 + 기준";
 "menu.about" = "AgentLimits 정보";
 "menu.quit" = "종료";
@@ -45,7 +44,6 @@
 /* Display Mode */
 "displayMode.used" = "사용률";
 "displayMode.remaining" = "잔여 사용률";
-"displayMode.ideal" = "기준";
 "displayMode.usedWithIdeal" = "사용률 + 기준";
 
 /* Status */

--- a/AgentLimits/ko.lproj/Localizable.strings
+++ b/AgentLimits/ko.lproj/Localizable.strings
@@ -183,3 +183,9 @@
 "widgetTapAction.openWebsite" = "웹사이트 열기";
 "widgetTapAction.refreshData" = "데이터 새로 고침";
 "widgetTapAction.note" = "위젯을 탭했을 때의 동작을 선택합니다";
+
+/* Ideal Mode Thresholds */
+"notification.idealModeThresholds" = "Guideline Mode Thresholds";
+"notification.idealModeThresholds.description" = "Color thresholds when exceeding guideline";
+"notification.idealModeThresholds.warning" = "Warning (Orange)";
+"notification.idealModeThresholds.danger" = "Danger (Red)";

--- a/AgentLimits/ko.lproj/Localizable.strings
+++ b/AgentLimits/ko.lproj/Localizable.strings
@@ -9,6 +9,8 @@
 "menu.displayMode" = "표시 모드";
 "menu.displayMode.used" = "사용률";
 "menu.displayMode.remaining" = "잔여 사용률";
+"menu.displayMode.ideal" = "기준";
+"menu.displayMode.usedWithIdeal" = "사용률 + 기준";
 "menu.about" = "AgentLimits 정보";
 "menu.quit" = "종료";
 "menu.language" = "언어";
@@ -43,6 +45,8 @@
 /* Display Mode */
 "displayMode.used" = "사용률";
 "displayMode.remaining" = "잔여 사용률";
+"displayMode.ideal" = "기준";
+"displayMode.usedWithIdeal" = "사용률 + 기준";
 
 /* Status */
 "status.notFetched" = "가져오지 못함";

--- a/AgentLimits/nl.lproj/Localizable.strings
+++ b/AgentLimits/nl.lproj/Localizable.strings
@@ -9,7 +9,6 @@
 "menu.displayMode" = "Weergavemodus";
 "menu.displayMode.used" = "Gebruikspercentage";
 "menu.displayMode.remaining" = "Resterend percentage";
-"menu.displayMode.ideal" = "Richtlijn";
 "menu.displayMode.usedWithIdeal" = "Gebruik + Richtlijn";
 "menu.about" = "Over AgentLimits";
 "menu.quit" = "Afsluiten";
@@ -45,7 +44,6 @@
 /* Display Mode */
 "displayMode.used" = "Gebruikspercentage";
 "displayMode.remaining" = "Resterend percentage";
-"displayMode.ideal" = "Richtlijn";
 "displayMode.usedWithIdeal" = "Gebruik + Richtlijn";
 
 /* Status */

--- a/AgentLimits/nl.lproj/Localizable.strings
+++ b/AgentLimits/nl.lproj/Localizable.strings
@@ -183,3 +183,9 @@
 "widgetTapAction.openWebsite" = "Website openen";
 "widgetTapAction.refreshData" = "Gegevens verversen";
 "widgetTapAction.note" = "Kies wat er gebeurt bij het tikken op een widget";
+
+/* Ideal Mode Thresholds */
+"notification.idealModeThresholds" = "Guideline Mode Thresholds";
+"notification.idealModeThresholds.description" = "Color thresholds when exceeding guideline";
+"notification.idealModeThresholds.warning" = "Warning (Orange)";
+"notification.idealModeThresholds.danger" = "Danger (Red)";

--- a/AgentLimits/nl.lproj/Localizable.strings
+++ b/AgentLimits/nl.lproj/Localizable.strings
@@ -9,6 +9,8 @@
 "menu.displayMode" = "Weergavemodus";
 "menu.displayMode.used" = "Gebruikspercentage";
 "menu.displayMode.remaining" = "Resterend percentage";
+"menu.displayMode.ideal" = "Richtlijn";
+"menu.displayMode.usedWithIdeal" = "Gebruik + Richtlijn";
 "menu.about" = "Over AgentLimits";
 "menu.quit" = "Afsluiten";
 "menu.language" = "Taal";
@@ -43,6 +45,8 @@
 /* Display Mode */
 "displayMode.used" = "Gebruikspercentage";
 "displayMode.remaining" = "Resterend percentage";
+"displayMode.ideal" = "Richtlijn";
+"displayMode.usedWithIdeal" = "Gebruik + Richtlijn";
 
 /* Status */
 "status.notFetched" = "Niet opgehaald";

--- a/AgentLimits/pl.lproj/Localizable.strings
+++ b/AgentLimits/pl.lproj/Localizable.strings
@@ -9,6 +9,8 @@
 "menu.displayMode" = "Tryb wyświetlania";
 "menu.displayMode.used" = "Wskaźnik użycia";
 "menu.displayMode.remaining" = "Pozostały wskaźnik";
+"menu.displayMode.ideal" = "Wzorzec";
+"menu.displayMode.usedWithIdeal" = "Użycie + Wzorzec";
 "menu.about" = "O AgentLimits";
 "menu.quit" = "Zakończ";
 "menu.language" = "Język";
@@ -43,6 +45,8 @@
 /* Display Mode */
 "displayMode.used" = "Wskaźnik użycia";
 "displayMode.remaining" = "Pozostały wskaźnik";
+"displayMode.ideal" = "Wzorzec";
+"displayMode.usedWithIdeal" = "Użycie + Wzorzec";
 
 /* Status */
 "status.notFetched" = "Nie pobrano";

--- a/AgentLimits/pl.lproj/Localizable.strings
+++ b/AgentLimits/pl.lproj/Localizable.strings
@@ -183,3 +183,9 @@
 "widgetTapAction.openWebsite" = "Otwórz stronę";
 "widgetTapAction.refreshData" = "Odśwież dane";
 "widgetTapAction.note" = "Wybierz, co ma się stać po stuknięciu widżetu";
+
+/* Ideal Mode Thresholds */
+"notification.idealModeThresholds" = "Guideline Mode Thresholds";
+"notification.idealModeThresholds.description" = "Color thresholds when exceeding guideline";
+"notification.idealModeThresholds.warning" = "Warning (Orange)";
+"notification.idealModeThresholds.danger" = "Danger (Red)";

--- a/AgentLimits/pl.lproj/Localizable.strings
+++ b/AgentLimits/pl.lproj/Localizable.strings
@@ -9,7 +9,6 @@
 "menu.displayMode" = "Tryb wyświetlania";
 "menu.displayMode.used" = "Wskaźnik użycia";
 "menu.displayMode.remaining" = "Pozostały wskaźnik";
-"menu.displayMode.ideal" = "Wzorzec";
 "menu.displayMode.usedWithIdeal" = "Użycie + Wzorzec";
 "menu.about" = "O AgentLimits";
 "menu.quit" = "Zakończ";
@@ -45,7 +44,6 @@
 /* Display Mode */
 "displayMode.used" = "Wskaźnik użycia";
 "displayMode.remaining" = "Pozostały wskaźnik";
-"displayMode.ideal" = "Wzorzec";
 "displayMode.usedWithIdeal" = "Użycie + Wzorzec";
 
 /* Status */

--- a/AgentLimits/pt-BR.lproj/Localizable.strings
+++ b/AgentLimits/pt-BR.lproj/Localizable.strings
@@ -9,7 +9,6 @@
 "menu.displayMode" = "Modo de exibição";
 "menu.displayMode.used" = "Taxa de uso";
 "menu.displayMode.remaining" = "Taxa restante";
-"menu.displayMode.ideal" = "Referência";
 "menu.displayMode.usedWithIdeal" = "Uso + Referência";
 "menu.about" = "Sobre o AgentLimits";
 "menu.quit" = "Sair";
@@ -45,7 +44,6 @@
 /* Display Mode */
 "displayMode.used" = "Taxa de uso";
 "displayMode.remaining" = "Taxa restante";
-"displayMode.ideal" = "Referência";
 "displayMode.usedWithIdeal" = "Uso + Referência";
 
 /* Status */

--- a/AgentLimits/pt-BR.lproj/Localizable.strings
+++ b/AgentLimits/pt-BR.lproj/Localizable.strings
@@ -183,3 +183,9 @@
 "widgetTapAction.openWebsite" = "Abrir site";
 "widgetTapAction.refreshData" = "Atualizar dados";
 "widgetTapAction.note" = "Escolha o que acontece ao tocar em um widget";
+
+/* Ideal Mode Thresholds */
+"notification.idealModeThresholds" = "Guideline Mode Thresholds";
+"notification.idealModeThresholds.description" = "Color thresholds when exceeding guideline";
+"notification.idealModeThresholds.warning" = "Warning (Orange)";
+"notification.idealModeThresholds.danger" = "Danger (Red)";

--- a/AgentLimits/pt-BR.lproj/Localizable.strings
+++ b/AgentLimits/pt-BR.lproj/Localizable.strings
@@ -9,6 +9,8 @@
 "menu.displayMode" = "Modo de exibição";
 "menu.displayMode.used" = "Taxa de uso";
 "menu.displayMode.remaining" = "Taxa restante";
+"menu.displayMode.ideal" = "Referência";
+"menu.displayMode.usedWithIdeal" = "Uso + Referência";
 "menu.about" = "Sobre o AgentLimits";
 "menu.quit" = "Sair";
 "menu.language" = "Idioma";
@@ -43,6 +45,8 @@
 /* Display Mode */
 "displayMode.used" = "Taxa de uso";
 "displayMode.remaining" = "Taxa restante";
+"displayMode.ideal" = "Referência";
+"displayMode.usedWithIdeal" = "Uso + Referência";
 
 /* Status */
 "status.notFetched" = "Não obtido";

--- a/AgentLimits/tr.lproj/Localizable.strings
+++ b/AgentLimits/tr.lproj/Localizable.strings
@@ -183,3 +183,9 @@
 "widgetTapAction.openWebsite" = "Web sitesini aç";
 "widgetTapAction.refreshData" = "Verileri yenile";
 "widgetTapAction.note" = "Widget'a dokunulduğunda ne olacağını seçin";
+
+/* Ideal Mode Thresholds */
+"notification.idealModeThresholds" = "Guideline Mode Thresholds";
+"notification.idealModeThresholds.description" = "Color thresholds when exceeding guideline";
+"notification.idealModeThresholds.warning" = "Warning (Orange)";
+"notification.idealModeThresholds.danger" = "Danger (Red)";

--- a/AgentLimits/tr.lproj/Localizable.strings
+++ b/AgentLimits/tr.lproj/Localizable.strings
@@ -9,6 +9,8 @@
 "menu.displayMode" = "Görüntüleme Modu";
 "menu.displayMode.used" = "Kullanım oranı";
 "menu.displayMode.remaining" = "Kalan oran";
+"menu.displayMode.ideal" = "Referans";
+"menu.displayMode.usedWithIdeal" = "Kullanım + Referans";
 "menu.about" = "AgentLimits Hakkında";
 "menu.quit" = "Çıkış";
 "menu.language" = "Dil";
@@ -43,6 +45,8 @@
 /* Display Mode */
 "displayMode.used" = "Kullanım oranı";
 "displayMode.remaining" = "Kalan oran";
+"displayMode.ideal" = "Referans";
+"displayMode.usedWithIdeal" = "Kullanım + Referans";
 
 /* Status */
 "status.notFetched" = "Getirilemedi";

--- a/AgentLimits/tr.lproj/Localizable.strings
+++ b/AgentLimits/tr.lproj/Localizable.strings
@@ -9,7 +9,6 @@
 "menu.displayMode" = "Görüntüleme Modu";
 "menu.displayMode.used" = "Kullanım oranı";
 "menu.displayMode.remaining" = "Kalan oran";
-"menu.displayMode.ideal" = "Referans";
 "menu.displayMode.usedWithIdeal" = "Kullanım + Referans";
 "menu.about" = "AgentLimits Hakkında";
 "menu.quit" = "Çıkış";
@@ -45,7 +44,6 @@
 /* Display Mode */
 "displayMode.used" = "Kullanım oranı";
 "displayMode.remaining" = "Kalan oran";
-"displayMode.ideal" = "Referans";
 "displayMode.usedWithIdeal" = "Kullanım + Referans";
 
 /* Status */

--- a/AgentLimits/uk.lproj/Localizable.strings
+++ b/AgentLimits/uk.lproj/Localizable.strings
@@ -9,6 +9,8 @@
 "menu.displayMode" = "Режим відображення";
 "menu.displayMode.used" = "Рівень використання";
 "menu.displayMode.remaining" = "Залишок";
+"menu.displayMode.ideal" = "Орієнтир";
+"menu.displayMode.usedWithIdeal" = "Використання + Орієнтир";
 "menu.about" = "Про AgentLimits";
 "menu.quit" = "Вийти";
 "menu.language" = "Мова";
@@ -43,6 +45,8 @@
 /* Display Mode */
 "displayMode.used" = "Рівень використання";
 "displayMode.remaining" = "Залишок";
+"displayMode.ideal" = "Орієнтир";
+"displayMode.usedWithIdeal" = "Використання + Орієнтир";
 
 /* Status */
 "status.notFetched" = "Не отримано";

--- a/AgentLimits/uk.lproj/Localizable.strings
+++ b/AgentLimits/uk.lproj/Localizable.strings
@@ -183,3 +183,9 @@
 "widgetTapAction.openWebsite" = "Відкрити сайт";
 "widgetTapAction.refreshData" = "Оновити дані";
 "widgetTapAction.note" = "Виберіть, що відбудеться при торканні віджета";
+
+/* Ideal Mode Thresholds */
+"notification.idealModeThresholds" = "Guideline Mode Thresholds";
+"notification.idealModeThresholds.description" = "Color thresholds when exceeding guideline";
+"notification.idealModeThresholds.warning" = "Warning (Orange)";
+"notification.idealModeThresholds.danger" = "Danger (Red)";

--- a/AgentLimits/uk.lproj/Localizable.strings
+++ b/AgentLimits/uk.lproj/Localizable.strings
@@ -9,7 +9,6 @@
 "menu.displayMode" = "Режим відображення";
 "menu.displayMode.used" = "Рівень використання";
 "menu.displayMode.remaining" = "Залишок";
-"menu.displayMode.ideal" = "Орієнтир";
 "menu.displayMode.usedWithIdeal" = "Використання + Орієнтир";
 "menu.about" = "Про AgentLimits";
 "menu.quit" = "Вийти";
@@ -45,7 +44,6 @@
 /* Display Mode */
 "displayMode.used" = "Рівень використання";
 "displayMode.remaining" = "Залишок";
-"displayMode.ideal" = "Орієнтир";
 "displayMode.usedWithIdeal" = "Використання + Орієнтир";
 
 /* Status */

--- a/AgentLimits/zh-Hans.lproj/Localizable.strings
+++ b/AgentLimits/zh-Hans.lproj/Localizable.strings
@@ -9,6 +9,8 @@
 "menu.displayMode" = "显示模式";
 "menu.displayMode.used" = "使用率";
 "menu.displayMode.remaining" = "剩余率";
+"menu.displayMode.ideal" = "参考值";
+"menu.displayMode.usedWithIdeal" = "使用率 + 参考";
 "menu.about" = "关于 AgentLimits";
 "menu.quit" = "退出";
 "menu.language" = "语言";
@@ -43,6 +45,8 @@
 /* Display Mode */
 "displayMode.used" = "使用率";
 "displayMode.remaining" = "剩余率";
+"displayMode.ideal" = "参考值";
+"displayMode.usedWithIdeal" = "使用率 + 参考";
 
 /* Status */
 "status.notFetched" = "未获取";

--- a/AgentLimits/zh-Hans.lproj/Localizable.strings
+++ b/AgentLimits/zh-Hans.lproj/Localizable.strings
@@ -9,7 +9,6 @@
 "menu.displayMode" = "显示模式";
 "menu.displayMode.used" = "使用率";
 "menu.displayMode.remaining" = "剩余率";
-"menu.displayMode.ideal" = "参考值";
 "menu.displayMode.usedWithIdeal" = "使用率 + 参考";
 "menu.about" = "关于 AgentLimits";
 "menu.quit" = "退出";
@@ -45,7 +44,6 @@
 /* Display Mode */
 "displayMode.used" = "使用率";
 "displayMode.remaining" = "剩余率";
-"displayMode.ideal" = "参考值";
 "displayMode.usedWithIdeal" = "使用率 + 参考";
 
 /* Status */

--- a/AgentLimits/zh-Hans.lproj/Localizable.strings
+++ b/AgentLimits/zh-Hans.lproj/Localizable.strings
@@ -183,3 +183,9 @@
 "widgetTapAction.openWebsite" = "打开网站";
 "widgetTapAction.refreshData" = "刷新数据";
 "widgetTapAction.note" = "选择点击小组件时的操作";
+
+/* Ideal Mode Thresholds */
+"notification.idealModeThresholds" = "Guideline Mode Thresholds";
+"notification.idealModeThresholds.description" = "Color thresholds when exceeding guideline";
+"notification.idealModeThresholds.warning" = "Warning (Orange)";
+"notification.idealModeThresholds.danger" = "Danger (Red)";

--- a/AgentLimits/zh-Hant.lproj/Localizable.strings
+++ b/AgentLimits/zh-Hant.lproj/Localizable.strings
@@ -9,7 +9,6 @@
 "menu.displayMode" = "顯示模式";
 "menu.displayMode.used" = "使用率";
 "menu.displayMode.remaining" = "剩餘率";
-"menu.displayMode.ideal" = "參考值";
 "menu.displayMode.usedWithIdeal" = "使用率 + 參考";
 "menu.about" = "關於 AgentLimits";
 "menu.quit" = "結束";
@@ -45,7 +44,6 @@
 /* Display Mode */
 "displayMode.used" = "使用率";
 "displayMode.remaining" = "剩餘率";
-"displayMode.ideal" = "參考值";
 "displayMode.usedWithIdeal" = "使用率 + 參考";
 
 /* Status */

--- a/AgentLimits/zh-Hant.lproj/Localizable.strings
+++ b/AgentLimits/zh-Hant.lproj/Localizable.strings
@@ -183,3 +183,9 @@
 "widgetTapAction.openWebsite" = "開啟網站";
 "widgetTapAction.refreshData" = "重新整理資料";
 "widgetTapAction.note" = "選擇點擊小工具時的動作";
+
+/* Ideal Mode Thresholds */
+"notification.idealModeThresholds" = "Guideline Mode Thresholds";
+"notification.idealModeThresholds.description" = "Color thresholds when exceeding guideline";
+"notification.idealModeThresholds.warning" = "Warning (Orange)";
+"notification.idealModeThresholds.danger" = "Danger (Red)";

--- a/AgentLimits/zh-Hant.lproj/Localizable.strings
+++ b/AgentLimits/zh-Hant.lproj/Localizable.strings
@@ -9,6 +9,8 @@
 "menu.displayMode" = "顯示模式";
 "menu.displayMode.used" = "使用率";
 "menu.displayMode.remaining" = "剩餘率";
+"menu.displayMode.ideal" = "參考值";
+"menu.displayMode.usedWithIdeal" = "使用率 + 參考";
 "menu.about" = "關於 AgentLimits";
 "menu.quit" = "結束";
 "menu.language" = "語言";
@@ -43,6 +45,8 @@
 /* Display Mode */
 "displayMode.used" = "使用率";
 "displayMode.remaining" = "剩餘率";
+"displayMode.ideal" = "參考值";
+"displayMode.usedWithIdeal" = "使用率 + 參考";
 
 /* Status */
 "status.notFetched" = "尚未取得";

--- a/AgentLimitsShared/UsageColorSettings.swift
+++ b/AgentLimitsShared/UsageColorSettings.swift
@@ -166,3 +166,53 @@ enum ColorHexCodec {
         #endif
     }
 }
+
+// MARK: - Ideal Mode Threshold Settings
+
+/// UserDefaults keys for ideal mode threshold customization.
+enum IdealModeThresholdKeys {
+    static let warningDelta = "ideal_mode_warning_delta"
+    static let dangerDelta = "ideal_mode_danger_delta"
+}
+
+/// Settings for ideal mode color thresholds (excess percentage).
+enum IdealModeThresholdSettings {
+    /// Default warning delta (orange when exceeding ideal by this amount)
+    static let defaultWarningDelta: Double = 0
+
+    /// Default danger delta (red when exceeding ideal by this amount)
+    static let defaultDangerDelta: Double = 10
+
+    /// Loads the warning delta (excess % to trigger orange).
+    static func loadWarningDelta() -> Double {
+        let defaults = AppGroupDefaults.shared
+        let value = defaults?.object(forKey: IdealModeThresholdKeys.warningDelta) as? Double
+        return value ?? defaultWarningDelta
+    }
+
+    /// Loads the danger delta (excess % to trigger red).
+    static func loadDangerDelta() -> Double {
+        let defaults = AppGroupDefaults.shared
+        let value = defaults?.object(forKey: IdealModeThresholdKeys.dangerDelta) as? Double
+        return value ?? defaultDangerDelta
+    }
+
+    /// Saves the warning delta.
+    static func saveWarningDelta(_ value: Double) {
+        let defaults = AppGroupDefaults.shared
+        defaults?.set(value, forKey: IdealModeThresholdKeys.warningDelta)
+    }
+
+    /// Saves the danger delta.
+    static func saveDangerDelta(_ value: Double) {
+        let defaults = AppGroupDefaults.shared
+        defaults?.set(value, forKey: IdealModeThresholdKeys.dangerDelta)
+    }
+
+    /// Resets to default values.
+    static func resetToDefaults() {
+        let defaults = AppGroupDefaults.shared
+        defaults?.removeObject(forKey: IdealModeThresholdKeys.warningDelta)
+        defaults?.removeObject(forKey: IdealModeThresholdKeys.dangerDelta)
+    }
+}

--- a/AgentLimitsShared/UsageModels.swift
+++ b/AgentLimitsShared/UsageModels.swift
@@ -701,6 +701,7 @@ extension UsageWindow {
     /// Returns nil if resetAt is unavailable.
     func calculateIdealUsagePercent() -> Double? {
         guard let resetAt = resetAt else { return nil }
+        guard limitWindowSeconds > 0 else { return nil }
         
         let now = Date()
         let windowStart = resetAt.addingTimeInterval(-limitWindowSeconds)

--- a/AgentLimitsShared/UsageModels.swift
+++ b/AgentLimitsShared/UsageModels.swift
@@ -103,15 +103,34 @@ enum CLICommandPathResolver {
 enum UsageDisplayModeRaw: String, Codable {
     case used
     case remaining
+    case ideal
+    case usedWithIdeal
 
     /// Returns the display percentage based on the stored used percent.
     func makeDisplayPercent(from usedPercent: Double) -> Double {
         let value: Double
         switch self {
-        case .used:
+        case .used, .usedWithIdeal:
             value = usedPercent
         case .remaining:
             value = 100 - usedPercent
+        case .ideal:
+            // For ideal mode without window context, return usedPercent as fallback
+            value = usedPercent
+        }
+        return max(0, min(100, value))
+    }
+
+    /// Returns the display percentage based on the stored used percent and optional window for time-based calculation.
+    func makeDisplayPercent(from usedPercent: Double, window: UsageWindow?) -> Double {
+        let value: Double
+        switch self {
+        case .used, .usedWithIdeal:
+            value = usedPercent
+        case .remaining:
+            value = 100 - usedPercent
+        case .ideal:
+            value = window?.calculateIdealUsagePercent() ?? 0
         }
         return max(0, min(100, value))
     }
@@ -164,6 +183,29 @@ enum UsageStatusLevelResolver {
         if clamped >= Double(usedDanger) { return .red }
         if clamped >= Double(usedWarning) { return .orange }
         return .green
+    }
+
+    /// Returns the status level for ideal mode based on comparison between actual and ideal usage.
+    /// - Parameters:
+    ///   - usedPercent: Actual usage percentage (0-100).
+    ///   - idealPercent: Ideal usage percentage based on elapsed time (0-100).
+    ///   - warningDelta: Delta threshold for warning state (default: 0 - any excess).
+    ///   - dangerDelta: Delta threshold for danger state (default: 10%).
+    static func levelForIdealMode(
+        usedPercent: Double,
+        idealPercent: Double,
+        warningDelta: Double = 0,
+        dangerDelta: Double = 10
+    ) -> UsageStatusLevel {
+        let diff = usedPercent - idealPercent
+        
+        if diff >= dangerDelta {
+            return .red      // Significantly exceeds ideal (10%+)
+        } else if diff > warningDelta {
+            return .orange   // Exceeds ideal
+        } else {
+            return .green    // At or below ideal
+        }
     }
 
     private static func clampThreshold(_ value: Int) -> Int {
@@ -652,6 +694,21 @@ struct UsageWindow: Codable {
     let resetAt: Date?
     /// Duration of the window in seconds
     let limitWindowSeconds: TimeInterval
+}
+
+extension UsageWindow {
+    /// Calculates the ideal usage percentage based on elapsed time within the window.
+    /// Returns nil if resetAt is unavailable.
+    func calculateIdealUsagePercent() -> Double? {
+        guard let resetAt = resetAt else { return nil }
+        
+        let now = Date()
+        let windowStart = resetAt.addingTimeInterval(-limitWindowSeconds)
+        let elapsed = now.timeIntervalSince(windowStart)
+        
+        let idealPercent = (elapsed / limitWindowSeconds) * 100
+        return max(0, min(100, idealPercent))
+    }
 }
 
 /// A snapshot of usage data for a provider at a specific point in time

--- a/AgentLimitsShared/UsageModels.swift
+++ b/AgentLimitsShared/UsageModels.swift
@@ -103,7 +103,6 @@ enum CLICommandPathResolver {
 enum UsageDisplayModeRaw: String, Codable {
     case used
     case remaining
-    case ideal
     case usedWithIdeal
 
     /// Returns the display percentage based on the stored used percent.
@@ -114,9 +113,6 @@ enum UsageDisplayModeRaw: String, Codable {
             value = usedPercent
         case .remaining:
             value = 100 - usedPercent
-        case .ideal:
-            // For ideal mode without window context, return usedPercent as fallback
-            value = usedPercent
         }
         return max(0, min(100, value))
     }
@@ -129,8 +125,6 @@ enum UsageDisplayModeRaw: String, Codable {
             value = usedPercent
         case .remaining:
             value = 100 - usedPercent
-        case .ideal:
-            value = window?.calculateIdealUsagePercent() ?? 0
         }
         return max(0, min(100, value))
     }

--- a/AgentLimitsWidget/AgentLimitsWidget.swift
+++ b/AgentLimitsWidget/AgentLimitsWidget.swift
@@ -452,8 +452,10 @@ private enum WidgetUsageColorResolver {
         }
         let level = UsageStatusLevelResolver.levelForIdealMode(
             usedPercent: window.usedPercent,
-            idealPercent: idealPercent
-        )
+            idealPercent: idealPercent,
+                warningDelta: IdealModeThresholdSettings.loadWarningDelta(),
+                dangerDelta: IdealModeThresholdSettings.loadDangerDelta()
+            )
         return statusColor(for: level)
     }
 
@@ -488,7 +490,9 @@ private enum WidgetUsageColorResolver {
             }
             let level = UsageStatusLevelResolver.levelForIdealMode(
                 usedPercent: window.usedPercent,
-                idealPercent: idealPercent
+                idealPercent: idealPercent,
+                warningDelta: IdealModeThresholdSettings.loadWarningDelta(),
+                dangerDelta: IdealModeThresholdSettings.loadDangerDelta()
             )
             return statusColor(for: level)
         }

--- a/AgentLimitsWidget/AgentLimitsWidget.swift
+++ b/AgentLimitsWidget/AgentLimitsWidget.swift
@@ -256,7 +256,7 @@ private struct UsageDonutColumnView: View {
     }
 
     private var statusColor: Color {
-        if displayMode == .ideal || displayMode == .usedWithIdeal {
+        if displayMode == .usedWithIdeal {
             return WidgetUsageColorResolver.statusColorForIdealMode(for: window)
         }
         return WidgetUsageColorResolver.statusColor(for: window, provider: provider, windowKind: windowKind)
@@ -302,7 +302,7 @@ private struct UsageDonutView: View {
     }
 
     private var ringColor: Color {
-        if displayMode == .ideal || displayMode == .usedWithIdeal {
+        if displayMode == .usedWithIdeal {
             return WidgetUsageColorResolver.donutRingColorForIdealMode(window: window)
         }
         return WidgetUsageColorResolver.donutRingColor(

--- a/AgentLimitsWidget/AgentLimitsWidget.swift
+++ b/AgentLimitsWidget/AgentLimitsWidget.swift
@@ -256,7 +256,7 @@ private struct UsageDonutColumnView: View {
     }
 
     private var statusColor: Color {
-        if displayMode == .ideal {
+        if displayMode == .ideal || displayMode == .usedWithIdeal {
             return WidgetUsageColorResolver.statusColorForIdealMode(for: window)
         }
         return WidgetUsageColorResolver.statusColor(for: window, provider: provider, windowKind: windowKind)
@@ -302,7 +302,7 @@ private struct UsageDonutView: View {
     }
 
     private var ringColor: Color {
-        if displayMode == .ideal {
+        if displayMode == .ideal || displayMode == .usedWithIdeal {
             return WidgetUsageColorResolver.donutRingColorForIdealMode(window: window)
         }
         return WidgetUsageColorResolver.donutRingColor(


### PR DESCRIPTION
## 概要
時間経過に基づいて「今の時点でどれくらい使用しているのが理想的か」を計算し、実際の使用率と比較表示する機能を追加。

### 新しい表示モード
| モード | 表示形式 | 説明 |
|--------|----------|------|
| 使用率+目安 | `25(19)%` | 実際の使用率（理想的な使用率） |

### 色分けロジック（比較ベース、ユーザー設定可能）
| 状態 | 条件（デフォルト） | 色 |
|------|-------------------|-----|
| 正常 | 実際 ≤ 理想 + 警告閾値 | 緑 |
| 警告 | 実際 > 理想 + 警告閾値 | オレンジ |
| 危険 | 実際 ≥ 理想 + 危険閾値 | 赤 |

### 目安モード閾値設定
設定 → 通知 → 「目安モード閾値」セクションで設定可能：
- 警告（オレンジ）: デフォルト +0%
- 危険（赤）: デフォルト +10%

## 変更ファイル
- `AgentLimitsShared/UsageModels.swift` - 理想使用率計算ロジック、色判定
- `AgentLimitsShared/UsageColorSettings.swift` - 目安モード閾値設定の保存/読込
- `AgentLimits/Usage/AppUsageModels.swift` - 表示モードenum拡張
- `AgentLimits/App/AgentLimitsApp.swift` - メニューバー表示・色判定
- `AgentLimits/Notification/ThresholdSettingsView.swift` - 目安モード閾値設定UI
- `AgentLimits/Scripts/agentlimits_statusline_claude.sh` - ステータスライン対応
- `AgentLimitsWidget/AgentLimitsWidget.swift` - ウィジェット対応
- `*.lproj/Localizable.strings` - 14言語のローカライゼーション

## ウィジェットへの影響
この機能はウィジェットにも影響があります：
- 表示モード設定はApp Group経由で共有されるため
- ウィジェットでも同じ色判定ロジックが適用される
- **オーナーによるウィジェットの動作確認が必要です**

## ステータスラインスクリプト

### 使用方法
```bash
./agentlimits_statusline_claude.sh           # アプリ設定に同期
./agentlimits_statusline_claude.sh -i        # usedWithIdeal モードを強制
./agentlimits_statusline_claude.sh -ja -i    # 日本語 + usedWithIdeal モード
```

### 出力例（usedWithIdeal モード）
```
🕔 5h: 25(19)% (Resets at 16:00) / 📅 1w: 18(14)% (Resets at 2026-01-23 08:00) - Updated 14:03
```

## テスト項目
- [ ] メニューバー: 「使用率+目安」モードで `X(Y)%` 形式表示
- [ ] 色判定: 設定した閾値で緑/オレンジ/赤が変わる
- [ ] 設定画面: 「目安モード閾値」セクションでスライダー操作可能
- [ ] ウィジェット: 同様の表示・色判定
- [ ] ステータスラインスクリプト: `-i` オプションで正しく動作
- [ ] 14言語のローカライゼーション確認

🤖 Generated with [Claude Code](https://claude.ai/code)