### PR TITLE
fix: Codex usage URLを新パスに更新

### DIFF
--- a/AgentLimitsShared/UsageModels.swift
+++ b/AgentLimitsShared/UsageModels.swift
@@ -607,7 +607,7 @@ enum UsageProvider: String, Codable, CaseIterable, Identifiable, SnapshotFileNam
     // These are defined as static properties to ensure they are only created once.
 
     /// Codex usage settings page URL
-    private static let codexUsageURL = URL(string: "https://chatgpt.com/codex/settings/usage")
+    private static let codexUsageURL = URL(string: "https://chatgpt.com/codex/cloud/settings/usage")
     /// Claude usage settings page URL
     private static let claudeUsageURL = URL(string: "https://claude.ai/settings/usage")
     /// GitHub Copilot billing usage page URL


### PR DESCRIPTION
## Summary
- ChatGPT側のリダイレクト追加により `/codex/settings/usage` が `/codex/cloud/settings/usage` に遷移するようになった
- アプリの `usageURL` 定数が旧パスのままで、`isUsageURL` 判定が常に不一致となり、`handleLoginAndFetch` → `reloadFromOrigin` の無限ループでCodexログインが完了できなかった
- [AgentLimitsShared/UsageModels.swift](AgentLimitsShared/UsageModels.swift#L610) の `codexUsageURL` を新パスに更新

## Test plan
- [ ] Codexをログアウト状態から内蔵WebViewでログインし、リロードループに陥らずログインが完了すること
- [ ] ログイン後にusage画面が表示され、snapshotが取得できること
- [ ] Claude / Copilot のログイン・更新が回帰していないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)