### PR TITLE
fix(ContentView): remove fixedSize to prevent login panel from going off-screen on macOS 26

### DIFF
--- a/AgentLimits/Usage/ContentView.swift
+++ b/AgentLimits/Usage/ContentView.swift
@@ -86,7 +86,6 @@ struct ContentView: View {
                         }
                     }
                     .formStyle(.grouped)
-                    .fixedSize(horizontal: false, vertical: true)
                 }
                 .padding(DesignTokens.Spacing.large)
                 .padding(.bottom, webViewPanelCollapsedHeight + DesignTokens.Spacing.large)


### PR DESCRIPTION
On macOS 26 (Tahoe), the new design language increases form section heights. The `.fixedSize(vertical: true)` modifier caused the Form to expand to its full natural height, making the ZStack taller than the window. This pushed the "Login to get current usage rate" panel below the visible area, leaving users stuck on "Loading login page..." with no way to authenticate.

Removing `.fixedSize(vertical: true)` lets the Form fill the available space and scroll internally (its underlying List already handles this), keeping the login panel always visible at the bottom of the window.