### PR TITLE
feat(fetch): Add Claude and Codex authentication with usage tracking features

### DIFF
--- a/AgentLimits.xcodeproj/project.pbxproj
+++ b/AgentLimits.xcodeproj/project.pbxproj
@@ -234,6 +234,7 @@
 				nl,
 				tr,
 				uk,
+				th,
 			);
 			mainGroup = 42D45B812EF649FD00A51EA8;
 			minimizedProjectReferenceProxies = 1;
@@ -436,6 +437,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 11;
 				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = TW5U7LRTPP;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -445,7 +447,7 @@
 				INFOPLIST_KEY_CFBundleName = AgentLimits;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_LSUIElement = YES;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2025-2026 Nihondo";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -478,6 +480,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 11;
 				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = TW5U7LRTPP;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -487,7 +490,7 @@
 				INFOPLIST_KEY_CFBundleName = AgentLimits;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_LSUIElement = YES;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2025-2026 Nihondo";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -518,6 +521,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 11;
 				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = TW5U7LRTPP;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -555,6 +559,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 11;
 				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = TW5U7LRTPP;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/AgentLimits/Usage/AppUsageModels.swift
+++ b/AgentLimits/Usage/AppUsageModels.swift
@@ -154,7 +154,10 @@ extension UsageSnapshot {
             fetchedAt: fetchedAt,
             primaryWindow: primaryWindow,
             secondaryWindow: secondaryWindow,
-            displayMode: displayMode.makeDisplayModeRaw()
+            displayMode: displayMode.makeDisplayModeRaw(),
+            planType: planType,
+            limitReached: limitReached,
+            extraUsage: extraUsage
         )
     }
 }

--- a/AgentLimits/Usage/ClaudeUsageFetcher.swift
+++ b/AgentLimits/Usage/ClaudeUsageFetcher.swift
@@ -1,69 +1,129 @@
 // MARK: - ClaudeUsageFetcher.swift
-// Fetches usage data from Claude.ai via JavaScript injection.
-// Extracts organization ID from cookies or page content to call usage API.
+// Native Claude (Anthropic) usage fetcher. Reuses the user's already-granted
+// Claude Code OAuth session via the keychain item written by `claude /login`.
+// No WKWebView, no JS injection, no API keys — only the rotated OAuth tokens.
+//
+// Status-code matrix (per codex-island):
+//   200 + body.error.type == "rate_limit_error" → rateLimited
+//   200                                          → parse
+//   401                                          → refresh once + retry
+//   403 (scope insufficient: missing user:profile) → claudeReLogin
+//   429                                          → rateLimited
+//
+// 5-minute minimum poll interval is enforced upstream (UsageViewModel).
 
 import Foundation
-import WebKit
 
 // MARK: - API Response Models
 
-/// Response structure from Claude.ai usage API
+/// Response from `GET https://api.anthropic.com/api/oauth/usage`.
 struct ClaudeUsageResponse: Codable {
     struct Window: Codable {
         let utilization: Double?
-        let resets_at: String?
+        /// ISO8601 string OR epoch-seconds Double depending on field/account.
+        let resets_at: ResetsAt?
+    }
+
+    /// Discriminated union for `resets_at` — string OR number.
+    enum ResetsAt: Codable {
+        case iso(String)
+        case epoch(Double)
+        case absent
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            if container.decodeNil() { self = .absent; return }
+            if let s = try? container.decode(String.self) { self = .iso(s); return }
+            if let d = try? container.decode(Double.self) { self = .epoch(d); return }
+            self = .absent
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            switch self {
+            case .iso(let s): try container.encode(s)
+            case .epoch(let d): try container.encode(d)
+            case .absent: try container.encodeNil()
+            }
+        }
+    }
+
+    struct ExtraUsage: Codable {
+        let is_enabled: Bool?
+        let monthly_limit: Double?
+        let used_credits: Double?
+        let utilization: Double?
+        let currency: String?
+    }
+
+    /// Anthropic sometimes returns HTTP 200 with this error block instead of 429.
+    struct RateLimitErrorBody: Codable {
+        let type: String?
+        let message: String?
+    }
+
+    struct RateLimitErrorWrapper: Codable {
+        let error: RateLimitErrorBody?
     }
 
     let five_hour: Window?
     let seven_day: Window?
-    let seven_day_oauth_apps: Window?
-    let seven_day_opus: Window?
-    let seven_day_sonnet: Window?
-    let iguana_necktie: Window?
-    let extra_usage: Window?
+    let extra_usage: ExtraUsage?
 }
 
 extension ClaudeUsageResponse {
-    /// Converts API response to a UsageSnapshot for persistence and display.
-    /// - Parameters:
-    ///   - fetchedAt: The timestamp when this data was fetched
-    ///   - parseResetDate: Function to parse ISO8601 date strings from the API
-    /// - Returns: A UsageSnapshot containing primary (5h) and secondary (7d) windows
-    func toSnapshot(fetchedAt: Date, parseResetDate: (String) -> Date?) -> UsageSnapshot {
+    func toSnapshot(fetchedAt: Date, planType: String?) -> UsageSnapshot {
         let primary = makeWindow(
-            kind: .primary,
             source: five_hour,
-            limitSeconds: UsageLimitDuration.fiveHours,
-            parseResetDate: parseResetDate
+            kind: .primary,
+            limitSeconds: UsageLimitDuration.fiveHours
         )
         let secondary = makeWindow(
-            kind: .secondary,
             source: seven_day,
-            limitSeconds: UsageLimitDuration.sevenDays,
-            parseResetDate: parseResetDate
+            kind: .secondary,
+            limitSeconds: UsageLimitDuration.sevenDays
         )
+        let extra = extra_usage.map {
+            ExtraUsageInfo(
+                isEnabled: $0.is_enabled ?? false,
+                monthlyLimit: $0.monthly_limit,
+                usedCredits: $0.used_credits,
+                utilization: $0.utilization,
+                currency: $0.currency
+            )
+        }
         return UsageSnapshot(
             provider: .claudeCode,
             fetchedAt: fetchedAt,
             primaryWindow: primary,
-            secondaryWindow: secondary
+            secondaryWindow: secondary,
+            planType: planType,
+            limitReached: false,
+            extraUsage: extra
         )
     }
 
     private func makeWindow(
-        kind: UsageWindowKind,
         source: Window?,
-        limitSeconds: TimeInterval,
-        parseResetDate: (String) -> Date?
+        kind: UsageWindowKind,
+        limitSeconds: TimeInterval
     ) -> UsageWindow? {
-        guard let source, let usedPercent = source.utilization else {
+        guard let source, let rawUtilization = source.utilization else { return nil }
+        // Codex-island contract: utilization arrives in [0, 100]. Clamp without
+        // a "raw > 1 ? raw/100 : raw" heuristic — that heuristic breaks at
+        // window reset when utilization legitimately enters (0, 1].
+        let usedPercent = max(0, min(100, rawUtilization))
+        let resetAt: Date?
+        switch source.resets_at {
+        case .iso(let s):
+            resetAt = ClaudeResetDateParser.parse(s)
+        case .epoch(let d):
+            resetAt = Date(timeIntervalSince1970: d)
+        case .absent, .none:
+            // Treat absent reset as "not yet initialized" — drop the window.
             return nil
         }
-        // resets_at が null の場合は初期状態として扱い、UsageWindow を作らない
-        guard let resetAtString = source.resets_at,
-              let resetAt = parseResetDate(resetAtString) else {
-            return nil
-        }
+        guard let resetAt else { return nil }
         return UsageWindow(
             kind: kind,
             usedPercent: usedPercent,
@@ -73,192 +133,162 @@ extension ClaudeUsageResponse {
     }
 }
 
-// MARK: - Error Types
+// MARK: - ISO8601 Parsing
 
-/// Errors that can occur when fetching Claude usage data
-enum ClaudeUsageFetcherError: LocalizedError {
-    case scriptFailed(String)
-    case invalidResponse
-    case missingOrganization
+enum ClaudeResetDateParser {
+    private static let withFractional: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+    private static let withoutFractional: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
 
-    var errorDescription: String? {
-        switch self {
-        case .scriptFailed(let message):
-            return "error.fetchFailed".localized(message)
-        case .invalidResponse:
-            return "error.parseFailed".localized()
-        case .missingOrganization:
-            return "error.missingOrg".localized()
+    static func parse(_ value: String) -> Date? {
+        if let d = withFractional.date(from: value) { return d }
+        if let d = withoutFractional.date(from: value) { return d }
+        // Normalize >3-digit fractional seconds to milliseconds.
+        if let trimmed = trimFractionalSeconds(value),
+           let d = withFractional.date(from: trimmed) {
+            return d
         }
+        return nil
+    }
+
+    private static func trimFractionalSeconds(_ value: String) -> String? {
+        guard let dotIdx = value.firstIndex(of: ".") else { return nil }
+        let fractionStart = value.index(after: dotIdx)
+        guard let suffixStart = value[fractionStart...].firstIndex(where: { $0 == "Z" || $0 == "+" || $0 == "-" }) else {
+            return nil
+        }
+        let fraction = value[fractionStart..<suffixStart]
+        if fraction.count <= 3 { return value }
+        let trimmedFraction = fraction.prefix(3)
+        return String(value[..<fractionStart]) + trimmedFraction + value[suffixStart...]
     }
 }
 
 // MARK: - Claude Usage Fetcher
 
-/// Fetches usage data from Claude.ai by executing JavaScript in WebView.
-/// Obtains organization ID from cookies or page content to authenticate.
+/// Fetches Claude usage by reusing the user's claude /login OAuth session.
 final class ClaudeUsageFetcher {
-    private let scriptRunner: WebViewScriptRunner
+    private let http: NativeUsageHTTPClient
+    private let oauthClient: ClaudeOAuthClient
 
-    init(scriptRunner: WebViewScriptRunner = WebViewScriptRunner()) {
-        self.scriptRunner = scriptRunner
+    init(
+        http: NativeUsageHTTPClient = NativeUsageHTTPClient(),
+        oauthClient: ClaudeOAuthClient = ClaudeOAuthClient()
+    ) {
+        self.http = http
+        self.oauthClient = oauthClient
     }
 
-    /// Fetches current usage snapshot by executing JavaScript in the WebView
-    @MainActor
-    func fetchUsageSnapshot(using webView: WKWebView) async throws -> UsageSnapshot {
-        let response: ClaudeUsageResponse
-        do {
-            response = try await scriptRunner.decodeJSONScript(
-                ClaudeUsageResponse.self,
-                script: Self.usageScript,
-                webView: webView
-            )
-        } catch let error as WebViewScriptRunnerError {
-            throw mapScriptError(error)
-        } catch {
-            throw ClaudeUsageFetcherError.invalidResponse
+    /// True when we can locate an access token without hitting the network.
+    /// Used by the UI to choose between "logged in" and "needs claude /login".
+    func hasValidSession() -> Bool {
+        if ProcessInfo.processInfo.environment[ClaudeOAuthConfig.envTokenVariable]?.isEmpty == false {
+            return true
         }
-        return response.toSnapshot(fetchedAt: Date(), parseResetDate: parseResetDate)
+        return (try? ClaudeKeychainStore.loadCredentials()) != nil
     }
 
-    /// Checks if user is logged in by verifying the session cookie
-    @MainActor
-    func hasValidSession(using webView: WKWebView) async -> Bool {
-        await hasValidSessionCookie(using: webView)
-    }
-
-    private func hasValidSessionCookie(using webView: WKWebView) async -> Bool {
-        let cookieStore = webView.configuration.websiteDataStore.httpCookieStore
-        return await withCheckedContinuation { continuation in
-            cookieStore.getAllCookies { cookies in
-                let now = Date()
-                // Look for a valid Claude session cookie scoped to claude.ai.
-                let isValid = cookies.contains { cookie in
-                    guard cookie.name == "sessionKey" else { return false }
-                    guard cookie.domain.hasSuffix("claude.ai") else { return false }
-                    if let expiresDate = cookie.expiresDate {
-                        return expiresDate > now
-                    }
-                    return true
+    /// Fetches the current usage snapshot. Throws `UsageAuthError`.
+    /// On 401, refreshes the OAuth tokens via the keychain refresh_token,
+    /// writes the rotated pair back, and retries the GET once.
+    func fetchUsageSnapshot() async throws -> UsageSnapshot {
+        let initial = try resolveAccessTokenAndPlan()
+        let accessToken = initial.accessToken
+        var planType = initial.planType
+        let raw = try await performUsageGET(accessToken: accessToken)
+        switch raw.response.statusCode {
+        case 200...299:
+            if let wrapper = try? JSONDecoder().decode(ClaudeUsageResponse.RateLimitErrorWrapper.self, from: raw.data),
+               wrapper.error?.type == "rate_limit_error" {
+                throw UsageAuthError.rateLimited
+            }
+            do {
+                let decoded = try JSONDecoder().decode(ClaudeUsageResponse.self, from: raw.data)
+                return decoded.toSnapshot(fetchedAt: Date(), planType: planType)
+            } catch {
+                throw UsageAuthError.invalidResponse(reason: error.localizedDescription)
+            }
+        case 401:
+            // Refresh once + retry. Refresh re-issues with the SAME scope, so
+            // 403 (scope insufficient) cannot be helped by refresh and we
+            // surface .claudeReLogin instead (handled in the 403 branch below).
+            let newAccess: String
+            do {
+                newAccess = try await oauthClient.refreshAndPersist()
+            } catch let refreshError as UsageAuthError {
+                throw refreshError
+            }
+            planType = (try? ClaudeKeychainStore.loadCredentials().payload.claudeAiOauth.subscriptionType) ?? planType
+            let retry = try await performUsageGET(accessToken: newAccess)
+            switch retry.response.statusCode {
+            case 200...299:
+                if let wrapper = try? JSONDecoder().decode(ClaudeUsageResponse.RateLimitErrorWrapper.self, from: retry.data),
+                   wrapper.error?.type == "rate_limit_error" {
+                    throw UsageAuthError.rateLimited
                 }
-                continuation.resume(returning: isValid)
+                do {
+                    let decoded = try JSONDecoder().decode(ClaudeUsageResponse.self, from: retry.data)
+                    return decoded.toSnapshot(fetchedAt: Date(), planType: planType)
+                } catch {
+                    throw UsageAuthError.invalidResponse(reason: error.localizedDescription)
+                }
+            case 401:
+                throw UsageAuthError.claudeAuthExpired
+            case 403:
+                throw UsageAuthError.claudeReLogin
+            case 429:
+                throw UsageAuthError.rateLimited
+            default:
+                throw UsageAuthError.httpStatus(code: retry.response.statusCode, body: retry.bodyString)
             }
+        case 403:
+            throw UsageAuthError.claudeReLogin
+        case 429:
+            throw UsageAuthError.rateLimited
+        default:
+            throw UsageAuthError.httpStatus(code: raw.response.statusCode, body: raw.bodyString)
         }
     }
 
-    private func mapScriptError(_ error: WebViewScriptRunnerError) -> ClaudeUsageFetcherError {
-        // Map script errors to user-facing domain errors.
-        switch error {
-        case .invalidResponse:
-            return .invalidResponse
-        case .scriptFailed(let message):
-            if message.contains("Missing organization id") {
-                return .missingOrganization
-            }
-            return .scriptFailed(message)
-        }
+    // MARK: - Helpers
+
+    private struct InitialResolution {
+        let accessToken: String
+        let planType: String?
     }
 
-    // MARK: - Date Parsing
-
-    /// Parses ISO8601 date string with various fractional second formats
-    private func parseResetDate(_ value: String) -> Date? {
-        // Try full ISO8601 with fractional seconds first.
-        if let date = Self.formatterWithFractionalSeconds.date(from: value) {
-            return date
+    /// Token resolution order, per codex-island:
+    /// 1. CLAUDE_CODE_OAUTH_TOKEN env var (Claude Desktop child processes)
+    /// 2. Keychain payload's accessToken
+    /// 3. Refresh handled later in the 401 branch (not pre-emptively here)
+    private func resolveAccessTokenAndPlan() throws -> InitialResolution {
+        if let env = ProcessInfo.processInfo.environment[ClaudeOAuthConfig.envTokenVariable],
+           !env.isEmpty {
+            let plan = (try? ClaudeKeychainStore.loadCredentials().payload.claudeAiOauth.subscriptionType)
+            return InitialResolution(accessToken: env, planType: plan)
         }
-        // Fallback to ISO8601 without fractional seconds.
-        if let date = Self.formatterWithoutFractionalSeconds.date(from: value) {
-            return date
-        }
-        // Normalize long fractional precision to milliseconds if needed.
-        if let trimmed = trimFractionalSeconds(value),
-           let date = Self.formatterWithFractionalSeconds.date(from: trimmed) {
-            return date
-        }
-        return nil
+        let (payload, _) = try ClaudeKeychainStore.loadCredentials()
+        return InitialResolution(
+            accessToken: payload.claudeAiOauth.accessToken,
+            planType: payload.claudeAiOauth.subscriptionType
+        )
     }
 
-    private func trimFractionalSeconds(_ value: String) -> String? {
-        guard let dotIndex = value.firstIndex(of: ".") else { return nil }
-        let fractionStart = value.index(after: dotIndex)
-        guard let suffixStart = value[fractionStart...].firstIndex(where: { $0 == "Z" || $0 == "+" || $0 == "-" }) else {
-            return nil
-        }
-        let fraction = value[fractionStart..<suffixStart]
-        if fraction.count <= 3 {
-            return value
-        }
-        // Truncate to milliseconds precision.
-        let trimmedFraction = fraction.prefix(3)
-        return String(value[..<fractionStart]) + trimmedFraction + value[suffixStart...]
+    private func performUsageGET(accessToken: String) async throws -> NativeUsageHTTPClient.RawResponse {
+        var request = URLRequest(url: ClaudeOAuthConfig.usageEndpoint)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue(ClaudeOAuthConfig.oauthBetaHeader, forHTTPHeaderField: "anthropic-beta")
+        request.setValue(ClaudeOAuthConfig.userAgent, forHTTPHeaderField: "User-Agent")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        return try await http.send(request)
     }
-
-    private static let formatterWithFractionalSeconds: ISO8601DateFormatter = {
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        return formatter
-    }()
-
-    private static let formatterWithoutFractionalSeconds: ISO8601DateFormatter = {
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime]
-        return formatter
-    }()
-
-    // MARK: - JavaScript Scripts
-
-    /// Script to fetch usage: finds org ID from cookie/resources/HTML, then calls API
-    private static let usageScript = """
-    return (async () => {
-      try {
-        function readCookieValue(name) {
-          const pattern = new RegExp("(?:^|; )" + name + "=([^;]*)");
-          const match = document.cookie.match(pattern);
-          return match ? decodeURIComponent(match[1]) : null;
-        }
-
-        function findOrgIdFromResources() {
-          const entries = performance.getEntriesByType("resource");
-          for (const entry of entries) {
-            if (!entry || !entry.name) { continue; }
-            const match = entry.name.match(/\\/api\\/organizations\\/([a-f0-9-]{36})\\/usage/);
-            if (match) { return match[1]; }
-          }
-          return null;
-        }
-
-        function findOrgIdFromHtml() {
-          const html = document.documentElement ? document.documentElement.innerHTML : "";
-          const match = html.match(/\\/api\\/organizations\\/([a-f0-9-]{36})\\/usage/);
-          return match ? match[1] : null;
-        }
-
-        const orgId = readCookieValue("lastActiveOrg")
-          || findOrgIdFromResources()
-          || findOrgIdFromHtml();
-        if (!orgId) {
-          throw new Error("Missing organization id");
-        }
-
-        const response = await fetch("https://claude.ai/api/organizations/" + orgId + "/usage", {
-          method: "GET",
-          credentials: "include",
-          headers: {
-            "Accept": "application/json"
-          }
-        });
-        if (!response.ok) {
-          throw new Error("HTTP " + response.status);
-        }
-        const data = await response.json();
-        return JSON.stringify(data);
-      } catch (error) {
-        const message = error && error.message ? error.message : String(error);
-        return JSON.stringify({ "__error": message });
-      }
-    })();
-    """
-
 }

--- a/AgentLimits/Usage/CodexUsageFetcher.swift
+++ b/AgentLimits/Usage/CodexUsageFetcher.swift
@@ -1,22 +1,29 @@
 // MARK: - CodexUsageFetcher.swift
-// Fetches usage data from ChatGPT Codex via JavaScript injection.
-// Uses access token from session API to authenticate usage endpoint.
+// Native Codex (ChatGPT) usage fetcher. Reads the access token written by the
+// Codex CLI at `~/.codex/auth.json` and calls the backend usage endpoint
+// directly via URLSession — no WKWebView, no JS injection.
+//
+// The Codex CLI rotates its own tokens; we never refresh on our side.
+// On HTTP 401 the user must run `codex login`, which we surface via
+// `UsageAuthError.codexAuthExpired`.
 
 import Foundation
-import WebKit
 
 // MARK: - API Response Models
 
-/// Response structure from ChatGPT Codex usage API
+/// Response structure from ChatGPT Codex usage API.
 struct CodexUsageResponse: Codable {
     struct RateLimit: Codable {
         struct Window: Codable {
             let used_percent: Double?
             let limit_window_seconds: Double?
             let reset_after_seconds: Double?
+            /// epoch-seconds.
             let reset_at: TimeInterval?
         }
 
+        let allowed: Bool?
+        let limit_reached: Bool?
         let primary_window: Window?
         let secondary_window: Window?
     }
@@ -30,31 +37,31 @@ extension CodexUsageResponse {
     private static let secondsEqualityTolerance: TimeInterval = 0.001
 
     func toSnapshot(fetchedAt: Date) -> UsageSnapshot {
-        let primary = makeWindow(
-            kind: .primary,
-            source: rate_limit?.primary_window
-        )
-        let secondary = makeWindow(
-            kind: .secondary,
-            source: rate_limit?.secondary_window
-        )
+        let limitReached = rate_limit?.limit_reached ?? false
+        let primary = makeWindow(source: rate_limit?.primary_window, kind: .primary)
+        let secondary = makeWindow(source: rate_limit?.secondary_window, kind: .secondary)
         return UsageSnapshot(
             provider: .chatgptCodex,
             fetchedAt: fetchedAt,
             primaryWindow: primary,
-            secondaryWindow: secondary
+            secondaryWindow: secondary,
+            planType: plan_type,
+            limitReached: limitReached,
+            extraUsage: nil
         )
     }
 
     private func makeWindow(
-        kind: UsageWindowKind,
-        source: RateLimit.Window?
+        source: RateLimit.Window?,
+        kind: UsageWindowKind
     ) -> UsageWindow? {
         guard let source,
               let usedPercent = source.used_percent,
               let limitSeconds = source.limit_window_seconds else {
             return nil
         }
+        // Skip "freshly reset" windows where 0% used and the entire window
+        // duration is still available (matches the prior WebView behavior).
         if usedPercent == 0,
            let resetAfterSeconds = source.reset_after_seconds,
            abs(limitSeconds - resetAfterSeconds) <= Self.secondsEqualityTolerance {
@@ -70,141 +77,48 @@ extension CodexUsageResponse {
     }
 }
 
-// MARK: - Error Types
-
-/// Errors that can occur when fetching Codex usage data
-enum CodexUsageFetcherError: LocalizedError {
-    case pageNotReady
-    case scriptFailed(String)
-    case invalidResponse
-
-    var errorDescription: String? {
-        switch self {
-        case .pageNotReady:
-            return "error.loginNotLoaded".localized()
-        case .scriptFailed(let message):
-            return "error.fetchFailed".localized(message)
-        case .invalidResponse:
-            return "error.parseFailed".localized()
-        }
-    }
-}
-
 // MARK: - Codex Usage Fetcher
 
-/// Fetches usage data from ChatGPT Codex by executing JavaScript in WebView.
-/// Authenticates via session API to get access token for usage endpoint.
+/// Fetches Codex usage via HTTPS using the CLI-rotated access token.
 final class CodexUsageFetcher {
-    private let scriptRunner: WebViewScriptRunner
+    private let http: NativeUsageHTTPClient
 
-    init(scriptRunner: WebViewScriptRunner = WebViewScriptRunner()) {
-        self.scriptRunner = scriptRunner
+    init(http: NativeUsageHTTPClient = NativeUsageHTTPClient()) {
+        self.http = http
     }
 
-    /// Fetches current usage snapshot by executing JavaScript in the WebView
-    @MainActor
-    func fetchUsageSnapshot(using webView: WKWebView) async throws -> UsageSnapshot {
-        let response: CodexUsageResponse
-        do {
-            // Execute usage API script and decode JSON response.
-            response = try await scriptRunner.decodeJSONScript(
-                CodexUsageResponse.self,
-                script: Self.usageScript,
-                webView: webView
-            )
-        } catch let error as WebViewScriptRunnerError {
-            // Map script runner errors to domain errors.
-            throw mapScriptError(error)
-        }
-        return response.toSnapshot(fetchedAt: Date())
+    /// Returns true when an access token can be read off disk. The actual
+    /// validity is only known by hitting the endpoint, but this is enough
+    /// for the UI to decide between "logged in" and "needs codex login".
+    func hasValidSession() -> Bool {
+        (try? CodexAuthStore.loadAccessToken()) != nil
     }
 
-    /// Checks if user is logged in by verifying access token exists
-    @MainActor
-    func hasValidSession(using webView: WKWebView) async -> Bool {
-        do {
-            // Check if session token is present in web context.
-            return try await scriptRunner.runBooleanScript(Self.loginCheckScript, webView: webView)
-        } catch {
-            return false
+    /// Fetches the current usage snapshot. Throws `UsageAuthError`.
+    func fetchUsageSnapshot() async throws -> UsageSnapshot {
+        let token = try CodexAuthStore.loadAccessToken()
+        guard let url = URL(string: "https://chatgpt.com/backend-api/wham/usage") else {
+            throw UsageAuthError.invalidResponse(reason: "invalid usage URL")
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        let raw = try await http.send(request)
+        switch raw.response.statusCode {
+        case 200...299:
+            do {
+                let decoded = try JSONDecoder().decode(CodexUsageResponse.self, from: raw.data)
+                return decoded.toSnapshot(fetchedAt: Date())
+            } catch {
+                throw UsageAuthError.invalidResponse(reason: error.localizedDescription)
+            }
+        case 401:
+            throw UsageAuthError.codexAuthExpired
+        case 429:
+            throw UsageAuthError.rateLimited
+        default:
+            throw UsageAuthError.httpStatus(code: raw.response.statusCode, body: raw.bodyString)
         }
     }
-
-    private func mapScriptError(_ error: WebViewScriptRunnerError) -> CodexUsageFetcherError {
-        // Translate script errors into user-facing fetcher errors.
-        switch error {
-        case .invalidResponse:
-            return .invalidResponse
-        case .scriptFailed(let message):
-            return .scriptFailed(message)
-        }
-    }
-
-    // MARK: - JavaScript Scripts
-
-    /// Shared JavaScript function to fetch session from ChatGPT API.
-    /// Tries both `/api/auth/session` and `/backend-api/auth/session` endpoints.
-    /// Returns the session object containing the access token, or null if not authenticated.
-    private static let fetchSessionScript = """
-        async function fetchSession() {
-          let response = await fetch("/api/auth/session", { credentials: "include" });
-          if (response.ok) {
-            return await response.json();
-          }
-          response = await fetch("/backend-api/auth/session", { credentials: "include" });
-          if (response.ok) {
-            return await response.json();
-          }
-          return null;
-        }
-    """
-
-    /// Script to fetch usage data: gets session token, then calls usage API.
-    /// Uses the shared fetchSession function to obtain authentication credentials.
-    private static let usageScript = """
-    return (async () => {
-      try {
-        \(fetchSessionScript)
-
-        const session = await fetchSession();
-        const accessToken = session && (session.accessToken || session.access_token);
-        if (!accessToken) {
-          throw new Error("Missing access token");
-        }
-
-        const response = await fetch("https://chatgpt.com/backend-api/wham/usage", {
-          method: "GET",
-          credentials: "include",
-          headers: {
-            "Accept": "application/json",
-            "Authorization": "Bearer " + accessToken
-          }
-        });
-        if (!response.ok) {
-          throw new Error("HTTP " + response.status);
-        }
-        const data = await response.json();
-        return JSON.stringify(data);
-      } catch (error) {
-        const message = error && error.message ? error.message : String(error);
-        return JSON.stringify({ "__error": message });
-      }
-    })();
-    """
-
-    /// Script to check login status by verifying access token exists.
-    /// Uses the shared fetchSession function to check authentication state.
-    private static let loginCheckScript = """
-    return (async () => {
-      try {
-        \(fetchSessionScript)
-
-        const session = await fetchSession();
-        const accessToken = session && (session.accessToken || session.access_token);
-        return !!accessToken;
-      } catch (error) {
-        return false;
-      }
-    })();
-    """
 }

--- a/AgentLimits/Usage/ContentView.swift
+++ b/AgentLimits/Usage/ContentView.swift
@@ -334,36 +334,190 @@ struct ContentView: View {
     }
 
     private var loginWebViewSection: some View {
-        ZStack {
-            ForEach(UsageProvider.allCases) { provider in
-                let store = webViewPool.getWebViewStore(for: provider)
-                WebViewRepresentable(store: store)
-                    .onReceive(store.$popupWebView) { popup in
-                        if let popup {
-                            popupWebView = popup
-                            popupWebViewStore = store
-                            // Set up login check callback for auto-close.
-                            store.onPopupNavigationFinished = { [weak viewModel] _ in
-                                guard let viewModel else { return false }
-                                return await viewModel.checkLoginStatus(for: store.provider)
-                            }
-                        } else {
-                            // Close sheet when popup is dismissed programmatically.
-                            if popupWebViewStore === store {
+        Group {
+            switch viewModel.selectedProvider {
+            case .chatgptCodex, .claudeCode:
+                NativeAuthStatusView(
+                    provider: viewModel.selectedProvider,
+                    snapshot: viewModel.snapshot,
+                    fetchStatuses: viewModel.fetchStatuses,
+                    onRefresh: { viewModel.fetchNow() }
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding(DesignTokens.Spacing.medium)
+            case .githubCopilot:
+                ZStack {
+                    let store = webViewPool.getWebViewStore(for: .githubCopilot)
+                    WebViewRepresentable(store: store)
+                        .onReceive(store.$popupWebView) { popup in
+                            if let popup {
+                                popupWebView = popup
+                                popupWebViewStore = store
+                                store.onPopupNavigationFinished = { [weak viewModel] _ in
+                                    guard let viewModel else { return false }
+                                    return await viewModel.checkLoginStatus(for: store.provider)
+                                }
+                            } else if popupWebViewStore === store {
                                 popupWebView = nil
                                 popupWebViewStore = nil
                             }
                         }
-                    }
-                .opacity(viewModel.selectedProvider == provider ? 1 : 0)
-                .allowsHitTesting(viewModel.selectedProvider == provider)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .layoutPriority(1)
+                .cornerRadius(DesignTokens.CornerRadius.medium)
             }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .layoutPriority(1)
-        .cornerRadius(DesignTokens.CornerRadius.medium)
     }
 
+}
+
+// MARK: - Native Auth Status
+
+/// Status panel shown in place of the WebView for native (CLI-credential)
+/// providers. Surfaces login state, subscription badge, and a re-auth button
+/// that detached-spawns the provider CLI to refresh the keychain item.
+private struct NativeAuthStatusView: View {
+    let provider: UsageProvider
+    let snapshot: UsageSnapshot?
+    let fetchStatuses: [UsageProvider: ProviderFetchStatus]
+    let onRefresh: () -> Void
+
+    @State private var isLoggedIn: Bool = false
+    @State private var didTriggerReauth: Bool = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.medium) {
+            HStack(spacing: DesignTokens.Spacing.small) {
+                Image(systemName: isLoggedIn ? "checkmark.shield.fill" : "exclamationmark.shield.fill")
+                    .foregroundStyle(isLoggedIn ? Color.green : Color.orange)
+                Text(headlineText)
+                    .font(.headline)
+                Spacer()
+                if let plan = snapshot?.planType, !plan.isEmpty {
+                    Text(plan.capitalized)
+                        .font(.caption)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Color.secondary.opacity(0.15))
+                        .clipShape(Capsule())
+                }
+            }
+            if let statusText = lastFetchText {
+                Text(statusText)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            Text(explanationText)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            HStack(spacing: DesignTokens.Spacing.small) {
+                Button(reauthButtonLabel) {
+                    triggerReauth()
+                }
+                .controlSize(.regular)
+                Button("nativeAuth.refresh".localized()) {
+                    onRefresh()
+                }
+                .controlSize(.regular)
+                Spacer()
+                if didTriggerReauth {
+                    Text("nativeAuth.waitingForLogin".localized())
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer(minLength: 0)
+        }
+        .onAppear(perform: refreshLoginState)
+        .onChange(of: snapshot?.fetchedAt) { _, _ in
+            refreshLoginState()
+        }
+    }
+
+    private var headlineText: String {
+        isLoggedIn
+            ? "nativeAuth.loggedIn".localized(provider.displayName)
+            : "nativeAuth.notLoggedIn".localized(provider.displayName)
+    }
+
+    private var explanationText: String {
+        switch provider {
+        case .chatgptCodex:
+            return "nativeAuth.explanationCodex".localized()
+        case .claudeCode:
+            return "nativeAuth.explanationClaude".localized()
+        case .githubCopilot:
+            return ""
+        }
+    }
+
+    private var reauthButtonLabel: String {
+        switch provider {
+        case .chatgptCodex:
+            return "nativeAuth.runCodexLogin".localized()
+        case .claudeCode:
+            return "nativeAuth.runClaudeLogin".localized()
+        case .githubCopilot:
+            return ""
+        }
+    }
+
+    private var lastFetchText: String? {
+        guard let status = fetchStatuses[provider] else { return nil }
+        switch status {
+        case .success(let date):
+            let formatter = DateFormatter()
+            formatter.timeStyle = .short
+            formatter.dateStyle = .none
+            return "usage.updated".localized() + formatter.string(from: date)
+        case .failure(let message):
+            return message
+        case .notFetched:
+            return "status.notFetched".localized()
+        }
+    }
+
+    private func refreshLoginState() {
+        switch provider {
+        case .chatgptCodex:
+            isLoggedIn = CodexUsageFetcher().hasValidSession()
+        case .claudeCode:
+            isLoggedIn = ClaudeUsageFetcher().hasValidSession()
+        case .githubCopilot:
+            isLoggedIn = false
+        }
+    }
+
+    private func triggerReauth() {
+        let launched: Bool
+        switch provider {
+        case .chatgptCodex:
+            launched = ClaudeCLILocator.launchCodexLogin()
+        case .claudeCode:
+            launched = ClaudeCLILocator.launchClaudeLogin()
+        case .githubCopilot:
+            launched = false
+        }
+        didTriggerReauth = launched
+        // Poll the credential store every 5s for up to 2 minutes for the
+        // rotated token to appear, then auto-trigger a fetch.
+        guard launched else { return }
+        Task { @MainActor in
+            let deadline = Date().addingTimeInterval(120)
+            while Date() < deadline {
+                try? await Task.sleep(for: .seconds(5))
+                refreshLoginState()
+                if isLoggedIn {
+                    didTriggerReauth = false
+                    onRefresh()
+                    return
+                }
+            }
+            didTriggerReauth = false
+        }
+    }
 }
 
 // MARK: - Popup WebView Sheet

--- a/AgentLimits/Usage/Native/ClaudeCLILocator.swift
+++ b/AgentLimits/Usage/Native/ClaudeCLILocator.swift
@@ -1,0 +1,99 @@
+// MARK: - ClaudeCLILocator.swift
+// Locates the `claude` (and `codex`) binary in well-known install locations
+// that GUI apps cannot discover via PATH. LaunchServices hands GUI processes
+// a stripped PATH (`/usr/bin:/bin:/usr/sbin:/sbin`), so `which claude` misses
+// every Homebrew/Bun/nvm install.
+
+import Foundation
+
+/// Probes well-known CLI install paths for the Claude Code / Codex CLIs.
+enum ClaudeCLILocator {
+    /// Returns the first matching `claude` binary, or nil.
+    static func locateClaudeBinary() -> String? {
+        // Honor user override first.
+        let override = CLICommandPathResolver.resolveExecutable(for: .claude, defaultName: "claude")
+        if override != "claude", CLICommandPathValidator.isExecutablePathValid(override) {
+            return (override as NSString).expandingTildeInPath
+        }
+        return locate(binaryName: "claude")
+    }
+
+    /// Returns the first matching `codex` binary, or nil.
+    static func locateCodexBinary() -> String? {
+        let override = CLICommandPathResolver.resolveExecutable(for: .codex, defaultName: "codex")
+        if override != "codex", CLICommandPathValidator.isExecutablePathValid(override) {
+            return (override as NSString).expandingTildeInPath
+        }
+        return locate(binaryName: "codex")
+    }
+
+    /// Probes the codex-island canonical install paths in priority order.
+    private static func locate(binaryName: String) -> String? {
+        let home = NSHomeDirectory()
+        var candidates = [
+            "/opt/homebrew/bin/\(binaryName)",
+            "/usr/local/bin/\(binaryName)",
+            "\(home)/.bun/bin/\(binaryName)",
+            "\(home)/.npm-global/bin/\(binaryName)",
+            "\(home)/.local/bin/\(binaryName)"
+        ]
+        if let nvmPath = highestNvmVersionPath(binaryName: binaryName, home: home) {
+            candidates.append(nvmPath)
+        }
+        for path in candidates {
+            if FileManager.default.isExecutableFile(atPath: path) {
+                return path
+            }
+        }
+        return nil
+    }
+
+    /// Finds the highest `~/.nvm/versions/node/<version>/bin/<binary>` if any.
+    /// "Highest" is naive lexicographic-descending (works for vMAJOR.MINOR.PATCH).
+    private static func highestNvmVersionPath(binaryName: String, home: String) -> String? {
+        let nvmDir = "\(home)/.nvm/versions/node"
+        guard let entries = try? FileManager.default.contentsOfDirectory(atPath: nvmDir) else {
+            return nil
+        }
+        let sorted = entries.sorted(by: >)
+        for version in sorted {
+            let path = "\(nvmDir)/\(version)/bin/\(binaryName)"
+            if FileManager.default.isExecutableFile(atPath: path) {
+                return path
+            }
+        }
+        return nil
+    }
+
+    /// Detached-spawns the Claude Code re-auth flow. Returns true if the
+    /// process was launched. The CLI handles browser + callback + keychain
+    /// write; we recover automatically on the next poll once the rotated
+    /// token appears in the keychain.
+    @discardableResult
+    static func launchClaudeLogin() -> Bool {
+        guard let claudePath = locateClaudeBinary() else { return false }
+        return spawnDetached(executablePath: claudePath, arguments: ["/login"])
+    }
+
+    /// Detached-spawns the Codex re-auth flow. Returns true on launch.
+    @discardableResult
+    static func launchCodexLogin() -> Bool {
+        guard let codexPath = locateCodexBinary() else { return false }
+        return spawnDetached(executablePath: codexPath, arguments: ["login"])
+    }
+
+    private static func spawnDetached(executablePath: String, arguments: [String]) -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = arguments
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        process.standardInput = FileHandle.nullDevice
+        do {
+            try process.run()
+            return true
+        } catch {
+            return false
+        }
+    }
+}

--- a/AgentLimits/Usage/Native/ClaudeKeychainStore.swift
+++ b/AgentLimits/Usage/Native/ClaudeKeychainStore.swift
@@ -1,0 +1,178 @@
+// MARK: - ClaudeKeychainStore.swift
+// Reads/writes the `Claude Code-credentials` keychain item via /usr/bin/security.
+// Uses Process directly with argv (no shell) so the JSON password value is
+// passed safely without shell-quoting hazards.
+//
+// CRITICAL: Anthropic rotates BOTH the access_token AND the refresh_token on
+// every refresh. The new pair MUST be written back into this keychain item
+// or Claude Code itself will 401 on its NEXT refresh and force the user to
+// re-run `claude /login`.
+
+import Foundation
+
+/// The decrypted payload stored inside the keychain item.
+/// Wire format is JSON; field names match what Claude Code itself writes.
+struct ClaudeCredentialsPayload: Codable, Equatable {
+    /// expiresAt is ms-since-epoch (not seconds).
+    struct ClaudeAiOAuth: Codable, Equatable {
+        var accessToken: String
+        var refreshToken: String
+        /// Milliseconds since 1970-01-01 00:00:00 UTC.
+        var expiresAt: Int64
+        var subscriptionType: String?
+        var scopes: [String]?
+    }
+    var claudeAiOauth: ClaudeAiOAuth
+}
+
+/// Reader/writer for the `Claude Code-credentials` keychain item.
+enum ClaudeKeychainStore {
+    /// In-memory cache of the discovered account name so we don't re-shell on
+    /// every refresh. The account name is whatever string the user's
+    /// `claude /login` happened to write — it isn't fixed.
+    private static var cachedAccount: String?
+
+    /// Loads the current credentials payload, alongside the keychain account
+    /// name (needed for write-back).
+    static func loadCredentials() throws -> (payload: ClaudeCredentialsPayload, account: String) {
+        let account = try resolveAccount()
+        let json = try readPasswordJSON(account: account)
+        let decoded: ClaudeCredentialsPayload
+        do {
+            decoded = try JSONDecoder().decode(ClaudeCredentialsPayload.self, from: Data(json.utf8))
+        } catch {
+            throw UsageAuthError.claudeAuthUnavailable(
+                reason: "keychain payload malformed: \(error.localizedDescription)"
+            )
+        }
+        return (decoded, account)
+    }
+
+    /// Writes back a credentials payload, preserving the existing account name.
+    /// Uses `add-generic-password -U` to update the existing item in place
+    /// (preserves keychain ACLs unlike a delete-then-add).
+    static func writeCredentials(_ payload: ClaudeCredentialsPayload, account: String) throws {
+        let encoded: Data
+        do {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys]
+            encoded = try encoder.encode(payload)
+        } catch {
+            throw UsageAuthError.claudeAuthUnavailable(
+                reason: "encode credentials: \(error.localizedDescription)"
+            )
+        }
+        guard let json = String(data: encoded, encoding: .utf8) else {
+            throw UsageAuthError.claudeAuthUnavailable(reason: "non-utf8 credentials JSON")
+        }
+        let result = runSecurity(arguments: [
+            "add-generic-password",
+            "-U",
+            "-s", ClaudeOAuthConfig.keychainService,
+            "-a", account,
+            "-w", json
+        ])
+        if result.exitCode != 0 {
+            throw UsageAuthError.claudeAuthUnavailable(
+                reason: "security add-generic-password failed (\(result.exitCode)): \(result.stderr.prefix(200))"
+            )
+        }
+        cachedAccount = account
+    }
+
+    /// Resolves the keychain account name. Caches the result.
+    /// `security find-generic-password -s "<service>"` prints a metadata block
+    /// containing an `"acct"<blob>="<value>"` line. We parse `<value>` from there.
+    private static func resolveAccount() throws -> String {
+        if let cached = cachedAccount {
+            return cached
+        }
+        let result = runSecurity(arguments: [
+            "find-generic-password",
+            "-s", ClaudeOAuthConfig.keychainService
+        ])
+        if result.exitCode != 0 {
+            throw UsageAuthError.claudeAuthUnavailable(
+                reason: "keychain item '\(ClaudeOAuthConfig.keychainService)' not found — run claude /login"
+            )
+        }
+        // `security` historically printed metadata to stderr; modern versions
+        // route to stdout. Parse whichever has the acct line.
+        let combined = result.stdout + "\n" + result.stderr
+        guard let account = parseAcctValue(from: combined) else {
+            throw UsageAuthError.claudeAuthUnavailable(
+                reason: "could not parse account name from security output"
+            )
+        }
+        cachedAccount = account
+        return account
+    }
+
+    private static func readPasswordJSON(account: String) throws -> String {
+        let result = runSecurity(arguments: [
+            "find-generic-password",
+            "-s", ClaudeOAuthConfig.keychainService,
+            "-a", account,
+            "-w"
+        ])
+        if result.exitCode != 0 {
+            throw UsageAuthError.claudeAuthUnavailable(
+                reason: "keychain read failed (\(result.exitCode)): \(result.stderr.prefix(200))"
+            )
+        }
+        let trimmed = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw UsageAuthError.claudeAuthUnavailable(reason: "empty keychain payload")
+        }
+        return trimmed
+    }
+
+    /// Parses `"acct"<blob>="value"` from the metadata block.
+    /// Both quoted and hex-blob forms exist; only the quoted variant is used
+    /// by Claude Code, which is the only producer of this keychain item.
+    private static func parseAcctValue(from text: String) -> String? {
+        // Find a line containing `"acct"<...>="..."` and extract the quoted value.
+        for line in text.split(whereSeparator: \.isNewline) {
+            let lineStr = String(line)
+            guard lineStr.contains("\"acct\"") else { continue }
+            // Look for `="..."` after the acct marker.
+            guard let equalsIdx = lineStr.range(of: "=\"") else { continue }
+            let afterEquals = lineStr[equalsIdx.upperBound...]
+            guard let closeQuote = afterEquals.firstIndex(of: "\"") else { continue }
+            return String(afterEquals[..<closeQuote])
+        }
+        return nil
+    }
+
+    // MARK: - /usr/bin/security subprocess
+
+    private struct SecurityResult {
+        let stdout: String
+        let stderr: String
+        let exitCode: Int32
+    }
+
+    /// Runs /usr/bin/security with argv — no shell, no quoting hazards.
+    private static func runSecurity(arguments: [String]) -> SecurityResult {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/security")
+        process.arguments = arguments
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+        do {
+            try process.run()
+        } catch {
+            return SecurityResult(stdout: "", stderr: "launch failed: \(error.localizedDescription)", exitCode: -1)
+        }
+        let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+        let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return SecurityResult(
+            stdout: String(data: stdoutData, encoding: .utf8) ?? "",
+            stderr: String(data: stderrData, encoding: .utf8) ?? "",
+            exitCode: process.terminationStatus
+        )
+    }
+}

--- a/AgentLimits/Usage/Native/ClaudeOAuthClient.swift
+++ b/AgentLimits/Usage/Native/ClaudeOAuthClient.swift
@@ -1,0 +1,100 @@
+// MARK: - ClaudeOAuthClient.swift
+// Performs the Anthropic OAuth refresh flow and writes the rotated token
+// pair back into the `Claude Code-credentials` keychain item.
+//
+// CRITICAL: Both access_token AND refresh_token rotate on every refresh.
+// The new pair MUST be written back to the keychain atomically or Claude
+// Code itself will 401 on its next refresh.
+
+import Foundation
+
+/// Executes the OAuth refresh flow against `platform.claude.com/v1/oauth/token`.
+struct ClaudeOAuthClient {
+    private let http: NativeUsageHTTPClient
+
+    init(http: NativeUsageHTTPClient = NativeUsageHTTPClient()) {
+        self.http = http
+    }
+
+    /// Refreshes the current credentials and writes the rotated pair back
+    /// to the keychain. Returns the new access token for immediate use.
+    /// Caller must already have determined that a refresh is needed
+    /// (the prior request returned 401, or the cached `expiresAt` is past).
+    func refreshAndPersist() async throws -> String {
+        let (existing, account) = try ClaudeKeychainStore.loadCredentials()
+        let refreshed = try await performRefresh(refreshToken: existing.claudeAiOauth.refreshToken)
+        let updatedPayload = ClaudeCredentialsPayload(
+            claudeAiOauth: .init(
+                accessToken: refreshed.accessToken,
+                refreshToken: refreshed.refreshToken,
+                expiresAt: refreshed.expiresAtMillis,
+                // Preserve everything else.
+                subscriptionType: existing.claudeAiOauth.subscriptionType,
+                scopes: existing.claudeAiOauth.scopes
+            )
+        )
+        try ClaudeKeychainStore.writeCredentials(updatedPayload, account: account)
+        return refreshed.accessToken
+    }
+
+    // MARK: - Refresh transport
+
+    private struct RefreshRequestBody: Encodable {
+        let grant_type: String
+        let refresh_token: String
+        let client_id: String
+    }
+
+    private struct RefreshResponseBody: Decodable {
+        let access_token: String
+        let refresh_token: String
+        let expires_in: Int   // seconds
+    }
+
+    /// Rotated tuple returned to the caller.
+    struct RefreshedTokens {
+        let accessToken: String
+        let refreshToken: String
+        /// ms-since-epoch.
+        let expiresAtMillis: Int64
+    }
+
+    private func performRefresh(refreshToken: String) async throws -> RefreshedTokens {
+        var request = URLRequest(url: ClaudeOAuthConfig.tokenEndpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue(ClaudeOAuthConfig.userAgent, forHTTPHeaderField: "User-Agent")
+        let body = RefreshRequestBody(
+            grant_type: "refresh_token",
+            refresh_token: refreshToken,
+            client_id: ClaudeOAuthConfig.clientID
+        )
+        do {
+            request.httpBody = try JSONEncoder().encode(body)
+        } catch {
+            throw UsageAuthError.invalidResponse(reason: "encode refresh body: \(error.localizedDescription)")
+        }
+        let raw = try await http.send(request)
+        guard (200...299).contains(raw.response.statusCode) else {
+            // 4xx on refresh means the refresh token is dead — user must re-login.
+            if raw.response.statusCode == 401 || raw.response.statusCode == 400 {
+                throw UsageAuthError.claudeAuthExpired
+            }
+            throw UsageAuthError.httpStatus(code: raw.response.statusCode, body: raw.bodyString)
+        }
+        let decoded: RefreshResponseBody
+        do {
+            decoded = try JSONDecoder().decode(RefreshResponseBody.self, from: raw.data)
+        } catch {
+            throw UsageAuthError.invalidResponse(reason: "decode refresh response: \(error.localizedDescription)")
+        }
+        let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+        let expiresAtMs = nowMs + Int64(decoded.expires_in) * 1000
+        return RefreshedTokens(
+            accessToken: decoded.access_token,
+            refreshToken: decoded.refresh_token,
+            expiresAtMillis: expiresAtMs
+        )
+    }
+}

--- a/AgentLimits/Usage/Native/ClaudeOAuthConfig.swift
+++ b/AgentLimits/Usage/Native/ClaudeOAuthConfig.swift
@@ -1,0 +1,57 @@
+// MARK: - ClaudeOAuthConfig.swift
+// Constants that the Anthropic OAuth/usage flow is contractually pinned to.
+// These ARE NOT secrets — `clientID` is the public Claude Code OAuth client
+// and is hardcoded in the upstream CLI as well. We reuse it so the user's
+// own already-granted session works.
+
+import Foundation
+
+/// Compile-time constants for the Claude Code OAuth flow.
+///
+/// `claudeCodeCLIVersion` is exposed as a settable constant so we can bump it
+/// without redeploying — Anthropic gates `/api/oauth/usage` on the
+/// `claude-code/X.Y.Z` User-Agent shape. A wrong version may still 401.
+enum ClaudeOAuthConfig {
+    /// Reported in `User-Agent: claude-code/<version>`.
+    /// Bump in lockstep with whatever Anthropic's current Claude Code CLI ships.
+    static let claudeCodeCLIVersion: String = "2.1.121"
+
+    /// Required OAuth beta gate header.
+    static let oauthBetaHeader: String = "oauth-2025-04-20"
+
+    /// Public Claude Code OAuth client_id — hardcoded in the upstream CLI.
+    static let clientID: String = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+
+    /// Usage endpoint (gated on User-Agent + Authorization).
+    static let usageEndpoint: URL = {
+        guard let url = URL(string: "https://api.anthropic.com/api/oauth/usage") else {
+            preconditionFailure("Invalid Claude usage endpoint URL")
+        }
+        return url
+    }()
+
+    /// OAuth token endpoint — migrated from console.anthropic.com to platform.claude.com.
+    /// The old host still resolves but is not the canonical issuer for fresh tokens.
+    static let tokenEndpoint: URL = {
+        guard let url = URL(string: "https://platform.claude.com/v1/oauth/token") else {
+            preconditionFailure("Invalid Claude token endpoint URL")
+        }
+        return url
+    }()
+
+    /// Computed User-Agent string.
+    static var userAgent: String {
+        "claude-code/\(claudeCodeCLIVersion)"
+    }
+
+    /// Keychain service name written by `claude /login`.
+    static let keychainService: String = "Claude Code-credentials"
+
+    /// Environment variable Claude Desktop sets for its child processes.
+    static let envTokenVariable: String = "CLAUDE_CODE_OAUTH_TOKEN"
+
+    /// Minimum poll interval (seconds) — Anthropic rate-limits aggressively.
+    /// Sub-5-minute polling burns the daily quota and triggers `rate_limit_error`
+    /// responses for the user's actual Claude Code sessions.
+    static let minimumPollInterval: TimeInterval = 5 * 60
+}

--- a/AgentLimits/Usage/Native/CodexAuthStore.swift
+++ b/AgentLimits/Usage/Native/CodexAuthStore.swift
@@ -1,0 +1,51 @@
+// MARK: - CodexAuthStore.swift
+// Reads the Codex CLI auth bundle from `~/.codex/auth.json` and returns the
+// current `tokens.access_token`. The Codex CLI rotates this on its own — we
+// only read it. On 401 from the usage endpoint the caller surfaces
+// `UsageAuthError.codexAuthExpired` and the user runs `codex login`.
+
+import Foundation
+
+/// Reads the Codex CLI's on-disk auth bundle.
+enum CodexAuthStore {
+    /// Absolute path to the Codex CLI auth file (tilde-expanded).
+    static var authFileURL: URL {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        return home.appendingPathComponent(".codex/auth.json", isDirectory: false)
+    }
+
+    /// Returns the current access token, or throws `UsageAuthError` describing why not.
+    static func loadAccessToken() throws -> String {
+        let url = authFileURL
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw UsageAuthError.codexAuthUnavailable(reason: "missing ~/.codex/auth.json — run codex login")
+        }
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
+        } catch {
+            throw UsageAuthError.codexAuthUnavailable(
+                reason: "cannot read auth.json: \(error.localizedDescription)"
+            )
+        }
+        let payload: CodexAuthPayload
+        do {
+            payload = try JSONDecoder().decode(CodexAuthPayload.self, from: data)
+        } catch {
+            throw UsageAuthError.codexAuthUnavailable(
+                reason: "malformed auth.json: \(error.localizedDescription)"
+            )
+        }
+        guard let token = payload.tokens?.access_token, !token.isEmpty else {
+            throw UsageAuthError.codexAuthUnavailable(reason: "no access_token in auth.json — run codex login")
+        }
+        return token
+    }
+
+    private struct CodexAuthPayload: Decodable {
+        struct Tokens: Decodable {
+            let access_token: String?
+        }
+        let tokens: Tokens?
+    }
+}

--- a/AgentLimits/Usage/Native/NativeUsageHTTPClient.swift
+++ b/AgentLimits/Usage/Native/NativeUsageHTTPClient.swift
@@ -1,0 +1,46 @@
+// MARK: - NativeUsageHTTPClient.swift
+// Thin URLSession wrapper used by the native Codex/Claude usage fetchers.
+// Returns the raw HTTPURLResponse alongside the body so callers can branch
+// on status (401 vs 403 vs 429) — codex-island's status-code matrix relies on
+// distinguishing these.
+
+import Foundation
+
+/// One-shot HTTP transport for the native usage fetchers.
+/// Intentionally lightweight: no retries (callers own retry semantics, see
+/// Claude refresh flow), no auth (callers attach headers explicitly).
+struct NativeUsageHTTPClient {
+    /// Pair of raw response bytes and the HTTPURLResponse so callers can
+    /// status-branch without re-parsing.
+    struct RawResponse {
+        let data: Data
+        let response: HTTPURLResponse
+
+        /// UTF-8 body string (best effort, for error reporting).
+        var bodyString: String {
+            String(data: data, encoding: .utf8) ?? ""
+        }
+    }
+
+    private let session: URLSession
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    /// Executes an HTTP request and returns the raw response pair.
+    /// Throws `UsageAuthError.transport` for transport-layer failures
+    /// (DNS, TLS, timeout). Status codes are propagated to the caller.
+    func send(_ request: URLRequest) async throws -> RawResponse {
+        let result: (Data, URLResponse)
+        do {
+            result = try await session.data(for: request)
+        } catch {
+            throw UsageAuthError.transport(underlying: error)
+        }
+        guard let http = result.1 as? HTTPURLResponse else {
+            throw UsageAuthError.invalidResponse(reason: "non-HTTP response")
+        }
+        return RawResponse(data: result.0, response: http)
+    }
+}

--- a/AgentLimits/Usage/Native/UsageAuthError.swift
+++ b/AgentLimits/Usage/Native/UsageAuthError.swift
@@ -1,0 +1,113 @@
+// MARK: - UsageAuthError.swift
+// Unified error sentinels for native Codex/Claude usage fetchers.
+// These are surfaced to the UI so it can show a re-auth button instead of a
+// generic "fetch failed" message.
+
+import Foundation
+
+/// Errors surfaced by the native (non-WebView) usage fetchers.
+///
+/// `localizedDescription` is intentionally stable English text — the codex-island
+/// contract specifies exact wording (`"auth expired — codex login"` and
+/// `"re-login: claude /login"`) so the UI layer can string-match on the
+/// sentinel. Localized variants are shown via the dedicated user-facing
+/// helpers in `ContentView`, not the raw `localizedDescription`.
+enum UsageAuthError: Error, LocalizedError, Equatable {
+    /// Codex auth token in `~/.codex/auth.json` is missing or rejected.
+    /// Recovery: user runs `codex login`.
+    case codexAuthExpired
+
+    /// Codex auth file present but unreadable / malformed.
+    case codexAuthUnavailable(reason: String)
+
+    /// Claude token failed (401 even after refresh) — refresh exhausted.
+    /// Recovery: user runs `claude /login`.
+    case claudeAuthExpired
+
+    /// Claude token returned 403 — scope insufficient (missing `user:profile`).
+    /// Recovery REQUIRES a fresh `claude /login` because refresh re-issues the
+    /// same scope set.
+    case claudeReLogin
+
+    /// Provider returned 429 or a 200 body with `rate_limit_error`.
+    case rateLimited
+
+    /// Claude keychain item not found.
+    case claudeAuthUnavailable(reason: String)
+
+    /// Unexpected HTTP status from the provider's usage endpoint.
+    case httpStatus(code: Int, body: String)
+
+    /// JSON decoding failure.
+    case invalidResponse(reason: String)
+
+    /// Outbound HTTP transport failure (DNS, TLS, timeout).
+    case transport(underlying: Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .codexAuthExpired:
+            return "auth expired — codex login"
+        case .codexAuthUnavailable(let reason):
+            return "codex auth unavailable: \(reason)"
+        case .claudeAuthExpired:
+            return "re-login: claude /login"
+        case .claudeReLogin:
+            return "re-login: claude /login"
+        case .rateLimited:
+            return "rate limited"
+        case .claudeAuthUnavailable(let reason):
+            return "claude auth unavailable: \(reason)"
+        case .httpStatus(let code, let body):
+            let preview = body.prefix(200)
+            return "HTTP \(code): \(preview)"
+        case .invalidResponse(let reason):
+            return "invalid response: \(reason)"
+        case .transport(let error):
+            return error.localizedDescription
+        }
+    }
+
+    /// Returns true when the user must take an action (re-login) to recover.
+    var requiresUserReauth: Bool {
+        switch self {
+        case .codexAuthExpired, .codexAuthUnavailable,
+             .claudeAuthExpired, .claudeReLogin, .claudeAuthUnavailable:
+            return true
+        case .rateLimited, .httpStatus, .invalidResponse, .transport:
+            return false
+        }
+    }
+
+    /// The CLI command the user should run to recover, if any.
+    var recoveryCLICommand: String? {
+        switch self {
+        case .codexAuthExpired, .codexAuthUnavailable:
+            return "codex login"
+        case .claudeAuthExpired, .claudeReLogin, .claudeAuthUnavailable:
+            return "claude /login"
+        default:
+            return nil
+        }
+    }
+
+    static func == (lhs: UsageAuthError, rhs: UsageAuthError) -> Bool {
+        switch (lhs, rhs) {
+        case (.codexAuthExpired, .codexAuthExpired),
+             (.claudeAuthExpired, .claudeAuthExpired),
+             (.claudeReLogin, .claudeReLogin),
+             (.rateLimited, .rateLimited):
+            return true
+        case (.codexAuthUnavailable(let l), .codexAuthUnavailable(let r)),
+             (.claudeAuthUnavailable(let l), .claudeAuthUnavailable(let r)),
+             (.invalidResponse(let l), .invalidResponse(let r)):
+            return l == r
+        case (.httpStatus(let lCode, let lBody), .httpStatus(let rCode, let rBody)):
+            return lCode == rCode && lBody == rBody
+        case (.transport, .transport):
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/AgentLimits/Usage/UsageViewModel.swift
+++ b/AgentLimits/Usage/UsageViewModel.swift
@@ -1,6 +1,13 @@
 // MARK: - UsageViewModel.swift
 // Central state management for usage data fetching and auto-refresh.
-// Coordinates WebView login detection, API fetching, and widget updates.
+//
+// Codex and Claude now bypass WKWebView entirely — they read credentials
+// from local CLI installs (`~/.codex/auth.json` / `Claude Code-credentials`
+// keychain item) and call the provider HTTPS endpoints directly. Copilot
+// continues to use the WebView pool because GitHub's billing endpoint is
+// only reachable from a logged-in browser session.
+//
+// 5-minute minimum poll interval enforced for Codex/Claude.
 
 import Combine
 import Foundation
@@ -8,11 +15,6 @@ import OSLog
 import WebKit
 import WidgetKit
 
-// MARK: - Usage View Model
-
-/// Main view model managing usage data state, auto-refresh, and provider switching.
-/// Coordinates between WebViews, fetchers, and the snapshot store.
-/// Uses ProviderStateManager for per-provider state management.
 @MainActor
 final class UsageViewModel: ObservableObject {
     @Published var snapshot: UsageSnapshot?
@@ -38,6 +40,11 @@ final class UsageViewModel: ObservableObject {
     private var autoRecoveryInFlight: Set<UsageProvider> = []
     private var lastLoginRedirectAt: [UsageProvider: Date] = [:]
 
+    /// Tracks the last successful fetch per provider. Used to enforce the
+    /// codex-island minimum 5-minute poll guard for Codex/Claude, which
+    /// share daily quotas with the user's actual CLI sessions.
+    private var lastSuccessfulFetchAt: [UsageProvider: Date] = [:]
+
     init(
         webViewPool: UsageWebViewPool,
         store: UsageSnapshotStore? = nil,
@@ -54,9 +61,7 @@ final class UsageViewModel: ObservableObject {
         let useClaudeFetcher = claudeFetcher ?? ClaudeUsageFetcher()
         let useCopilotFetcher = copilotFetcher ?? CopilotUsageFetcher()
         let useStateManager = stateManager ?? ProviderStateManager()
-        // Load cached snapshots into state manager
         useStateManager.loadCachedSnapshots(from: useStore)
-
         let selectedState = useStateManager.getState(for: selectedProvider)
 
         self.webViewPool = webViewPool
@@ -72,35 +77,43 @@ final class UsageViewModel: ObservableObject {
         self.statusMessage = selectedState.statusMessage
         self.isFetching = selectedState.isFetching
 
-        // Set up state change callback for menu bar updates
         useStateManager.onStateChange = { [weak self] in
             self?.objectWillChange.send()
+        }
+
+        // Seed lastSuccessfulFetchAt from cached snapshots so the 5-min guard
+        // survives an app restart.
+        for (provider, snapshot) in useStateManager.allSnapshots {
+            lastSuccessfulFetchAt[provider] = snapshot.fetchedAt
         }
     }
 
     // MARK: - Public Accessors
 
-    /// Returns all provider snapshots for menu bar status display
     var snapshots: [UsageProvider: UsageSnapshot] {
         stateManager.allSnapshots
     }
 
-    /// Returns latest fetch statuses for all providers (for summary UI)
     var fetchStatuses: [UsageProvider: ProviderFetchStatus] {
         stateManager.allFetchStatuses
     }
 
-    /// Checks if user is logged in for the specified provider.
-    /// Used by popup auto-close to detect OAuth completion.
+    /// Checks login state for `provider`. Native fetchers answer from
+    /// disk/keychain; Copilot still asks the WebView.
     func checkLoginStatus(for provider: UsageProvider) async -> Bool {
-        let webViewStore = webViewPool.getWebViewStore(for: provider)
-        return await checkLoginStatus(for: provider, using: webViewStore.webView)
+        switch provider {
+        case .chatgptCodex:
+            return codexFetcher.hasValidSession()
+        case .claudeCode:
+            return claudeFetcher.hasValidSession()
+        case .githubCopilot:
+            let webViewStore = webViewPool.getWebViewStore(for: provider)
+            return await checkLoginStatusViaWebView(for: provider, using: webViewStore.webView)
+        }
     }
 
     // MARK: - Auto Refresh
 
-    /// Starts the auto-refresh timer for eligible providers.
-    /// Uses AutoRefreshCoordinator to manage timer lifecycle.
     func startAutoRefresh() {
         guard autoRefreshCoordinator == nil else { return }
         autoRefreshCoordinator = AutoRefreshCoordinator(
@@ -112,13 +125,11 @@ final class UsageViewModel: ObservableObject {
         autoRefreshCoordinator?.start()
     }
 
-    /// Stops the auto-refresh timer
     func stopAutoRefresh() {
         autoRefreshCoordinator?.stop()
         autoRefreshCoordinator = nil
     }
 
-    /// Restarts the auto-refresh timer (useful when interval changes)
     func restartAutoRefresh() {
         stopAutoRefresh()
         startAutoRefresh()
@@ -126,37 +137,35 @@ final class UsageViewModel: ObservableObject {
 
     // MARK: - Manual Refresh
 
-    /// Triggers an immediate refresh for the specified provider (for widget tap)
     func refreshNow(for provider: UsageProvider) async {
-        await refreshSnapshot(for: provider)
+        await refreshSnapshot(for: provider, isManual: true)
     }
 
-    /// Triggers an immediate refresh for the current provider
     func fetchNow() {
         let provider = selectedProvider
-        // Record manual refresh intent to allow fetch on page-ready callback.
-        manualRefreshRequests.insert(provider)
-        let store = webViewPool.getWebViewStore(for: provider)
-        if isUsageURL(store.webView.url, provider: provider) && store.isPageReady {
-            // If already on the usage page, proceed directly to fetch.
-            _ = consumeManualRefreshRequest(for: provider)
-            Task {
-                await handleLoginAndFetch(for: provider)
+        switch provider {
+        case .chatgptCodex, .claudeCode:
+            Task { await refreshSnapshot(for: provider, isManual: true) }
+        case .githubCopilot:
+            manualRefreshRequests.insert(provider)
+            let webViewStore = webViewPool.getWebViewStore(for: provider)
+            if isUsageURL(webViewStore.webView.url, provider: provider) && webViewStore.isPageReady {
+                _ = consumeManualRefreshRequest(for: provider)
+                Task {
+                    await handleCopilotLoginAndFetch(for: provider)
+                }
+            } else {
+                webViewStore.reloadFromOrigin()
             }
-        } else {
-            // Otherwise reload to reach the usage page (login flow).
-            store.reloadFromOrigin()
         }
     }
 
     // MARK: - Provider State Management
 
-    /// Updates published properties when provider selection changes
     func updateSelectedProviderState() {
         let provider = selectedProvider
         let state = stateManager.getState(for: provider)
         Task { @MainActor in
-            // Prevent stale updates when selection changed mid-task.
             guard provider == self.selectedProvider else { return }
             snapshot = state.snapshot
             statusMessage = state.statusMessage
@@ -164,23 +173,20 @@ final class UsageViewModel: ObservableObject {
         }
     }
 
-    /// Updates display mode and persists to all snapshots
     func updateDisplayMode(_ displayMode: UsageDisplayMode) {
         let displayMode = displayMode.normalizedSelectableMode
-        // Apply new mode, persist it, and refresh UI state.
         self.displayMode = displayMode
         displayModeStore.applyDisplayMode(displayMode)
         updateSelectedProviderState()
     }
 
-    // MARK: - Page Ready Handling
+    // MARK: - WebView Hooks (Copilot only)
 
-    /// Called when WebView page finishes loading; triggers fetch if logged in
+    /// Page-ready callbacks only fire for Copilot now; ignored for native
+    /// providers so they don't accidentally trigger fetches.
     func handlePageReadyChange(for provider: UsageProvider, isReady: Bool) {
-        guard isReady else { return }
-        // Recovery Task が SPA 初期化待機を担うため、recovery 中は page-ready 経由の fetch をスキップ。
+        guard provider == .githubCopilot, isReady else { return }
         guard !autoRecoveryInFlight.contains(provider) else { return }
-        // Manual refresh has priority; otherwise honor auto-refresh eligibility.
         let isManualRefresh = consumeManualRefreshRequest(for: provider)
         let state = stateManager.getState(for: provider)
         if !isManualRefresh {
@@ -188,91 +194,154 @@ final class UsageViewModel: ObservableObject {
         }
         guard !state.isFetching else { return }
         Task {
-            await handleLoginAndFetch(for: provider)
+            await handleCopilotLoginAndFetch(for: provider)
         }
     }
 
-    /// Called when cookies change; triggers login-based navigation for Claude
     func handleCookieChange(for provider: UsageProvider) {
-        guard provider == .claudeCode || provider == .githubCopilot else { return }
-        let store = webViewPool.getWebViewStore(for: provider)
+        guard provider == .githubCopilot else { return }
+        let webViewStore = webViewPool.getWebViewStore(for: provider)
         Task {
-            // Only redirect when a valid session is detected and cooldown allows it.
-            let isLoggedIn = await checkLoginStatus(for: provider, using: store.webView)
+            let isLoggedIn = await checkLoginStatusViaWebView(for: provider, using: webViewStore.webView)
             guard isLoggedIn else { return }
-            guard !isUsageURL(store.webView.url, provider: provider) else { return }
+            guard !isUsageURL(webViewStore.webView.url, provider: provider) else { return }
             guard canRedirectLogin(for: provider) else { return }
-            store.reloadFromOrigin()
+            webViewStore.reloadFromOrigin()
         }
     }
+
+    // MARK: - Core Refresh
 
     private func refreshAutoEligibleProviders() async {
-        // Refresh providers that are enabled or selected.
         let eligibleProviders = stateManager.autoRefreshEligibleProviders(selectedProvider: selectedProvider)
         for provider in eligibleProviders {
-            // Recovery Task が進行中のプロバイダは auto refresh をスキップ。
             guard !autoRecoveryInFlight.contains(provider) else { continue }
-            await refreshSnapshot(for: provider)
+            await refreshSnapshot(for: provider, isManual: false)
         }
     }
 
-    private func refreshSnapshot(for provider: UsageProvider) async {
+    /// Performs a refresh for a provider with the appropriate transport.
+    /// `isManual` bypasses the 5-min minimum-poll guard.
+    private func refreshSnapshot(for provider: UsageProvider, isManual: Bool) async {
         let currentState = stateManager.getState(for: provider)
         guard !currentState.isFetching else { return }
 
-        let webViewStore = webViewPool.getWebViewStore(for: provider)
-        guard webViewStore.isPageReady else {
-            // Update status while waiting for login page to load.
-            stateManager.setStatusMessage("status.loadingLogin".localized(), for: provider)
-            return
-        }
-
-        // Track fetching state for both per-provider and selected provider UI.
-        stateManager.setFetching(true, for: provider)
-        if provider == selectedProvider {
-            isFetching = true
-        }
-        defer {
-            stateManager.setFetching(false, for: provider)
-            if provider == selectedProvider {
-                isFetching = false
+        // Enforce minimum poll for native providers, except on manual refresh.
+        if !isManual, providerEnforcesMinimumPoll(provider) {
+            if let last = lastSuccessfulFetchAt[provider],
+               Date().timeIntervalSince(last) < ClaudeOAuthConfig.minimumPollInterval {
+                return
             }
         }
 
+        switch provider {
+        case .chatgptCodex, .claudeCode:
+            await refreshNativeProvider(provider)
+        case .githubCopilot:
+            await refreshCopilot(provider)
+        }
+    }
+
+    /// True when sub-5-min polling for this provider is harmful to the user's
+    /// daily quota (Codex/Claude share quota with the user's CLI sessions).
+    private func providerEnforcesMinimumPoll(_ provider: UsageProvider) -> Bool {
+        switch provider {
+        case .chatgptCodex, .claudeCode:
+            return true
+        case .githubCopilot:
+            return false
+        }
+    }
+
+    // MARK: - Native Provider Refresh (Codex / Claude)
+
+    private func refreshNativeProvider(_ provider: UsageProvider) async {
+        stateManager.setFetching(true, for: provider)
+        if provider == selectedProvider { isFetching = true }
+        defer {
+            stateManager.setFetching(false, for: provider)
+            if provider == selectedProvider { isFetching = false }
+        }
+
         do {
-            // Fetch latest snapshot from provider and persist with display-mode marker.
-            let fetchedSnapshot = try await fetchSnapshot(for: provider, using: webViewStore.webView)
-            let snapshotToSave = fetchedSnapshot.makeSnapshot(for: displayMode)
+            let fetched: UsageSnapshot
+            switch provider {
+            case .chatgptCodex:
+                fetched = try await codexFetcher.fetchUsageSnapshot()
+            case .claudeCode:
+                fetched = try await claudeFetcher.fetchUsageSnapshot()
+            case .githubCopilot:
+                return
+            }
+            let snapshotToSave = fetched.makeSnapshot(for: displayMode)
             try store.saveSnapshot(snapshotToSave)
             displayModeStore.saveCachedDisplayMode(displayMode)
             stateManager.updateAfterSuccessfulFetch(snapshot: snapshotToSave, for: provider)
+            lastSuccessfulFetchAt[provider] = snapshotToSave.fetchedAt
+            stateManager.setStatusMessage("status.updated".localized(), for: provider)
+            if provider == selectedProvider {
+                self.snapshot = snapshotToSave
+                statusMessage = "status.updated".localized()
+            }
+            WidgetCenter.shared.reloadTimelines(ofKind: snapshotToSave.provider.widgetKind)
+            await ThresholdNotificationManager.shared.checkThresholdsIfNeeded(for: fetched)
+        } catch let error as UsageAuthError {
+            handleNativeFetchError(error, provider: provider)
+        } catch {
+            stateManager.setFetchStatus(.failure(error.localizedDescription), for: provider)
+            stateManager.setStatusMessage(error.localizedDescription, for: provider)
+            if provider == selectedProvider { statusMessage = error.localizedDescription }
+        }
+    }
+
+    private func handleNativeFetchError(_ error: UsageAuthError, provider: UsageProvider) {
+        if error.requiresUserReauth {
+            stateManager.setAutoRefreshEnabled(false, for: provider)
+        }
+        let message = error.errorDescription ?? "fetch failed"
+        stateManager.setFetchStatus(.failure(message), for: provider)
+        stateManager.setStatusMessage(message, for: provider)
+        if provider == selectedProvider { statusMessage = message }
+    }
+
+    // MARK: - Copilot Refresh (WebView)
+
+    private func refreshCopilot(_ provider: UsageProvider) async {
+        let webViewStore = webViewPool.getWebViewStore(for: provider)
+        guard webViewStore.isPageReady else {
+            stateManager.setStatusMessage("status.loadingLogin".localized(), for: provider)
+            return
+        }
+        stateManager.setFetching(true, for: provider)
+        if provider == selectedProvider { isFetching = true }
+        defer {
+            stateManager.setFetching(false, for: provider)
+            if provider == selectedProvider { isFetching = false }
+        }
+
+        do {
+            let fetched = try await copilotFetcher.fetchUsageSnapshot(using: webViewStore.webView)
+            let snapshotToSave = fetched.makeSnapshot(for: displayMode)
+            try store.saveSnapshot(snapshotToSave)
+            displayModeStore.saveCachedDisplayMode(displayMode)
+            stateManager.updateAfterSuccessfulFetch(snapshot: snapshotToSave, for: provider)
+            lastSuccessfulFetchAt[provider] = snapshotToSave.fetchedAt
             autoRecoveryInFlight.remove(provider)
             stateManager.setStatusMessage("status.updated".localized(), for: provider)
             if provider == selectedProvider {
                 self.snapshot = snapshotToSave
                 statusMessage = "status.updated".localized()
             }
-            // Notify widgets to refresh their timelines.
             WidgetCenter.shared.reloadTimelines(ofKind: snapshotToSave.provider.widgetKind)
-
-            // Check thresholds and send notifications if needed
-            await ThresholdNotificationManager.shared.checkThresholdsIfNeeded(for: fetchedSnapshot)
-
-            // Fetch Copilot billing data alongside usage limits
-            if provider == .githubCopilot {
-                Task { await fetchCopilotBilling(using: webViewStore.webView) }
-            }
+            await ThresholdNotificationManager.shared.checkThresholdsIfNeeded(for: fetched)
+            Task { await fetchCopilotBilling(using: webViewStore.webView) }
         } catch {
             if shouldDisableAutoRefresh(for: provider, error: error) {
                 if autoRecoveryInFlight.contains(provider) {
-                    // reload 後の再 fetch でも失敗 → 復旧不能と判定して auto refresh を無効化
                     autoRecoveryInFlight.remove(provider)
                     stateManager.setAutoRefreshEnabled(false, for: provider)
                 } else {
-                    // 初回失敗: stale な lastActiveOrg Cookie を削除してからリロードし orgId を再取得する。
-                    // page-ready 直後ではなく SPA が API コールを完了した後に fetch するため delayed Task を使う。
                     autoRecoveryInFlight.insert(provider)
-                    await clearOrgIdCookie(for: provider)
                     webViewPool.getWebViewStore(for: provider).reloadFromOrigin()
                     stateManager.setStatusMessage("status.loadingLogin".localized(), for: provider)
                     if provider == selectedProvider {
@@ -280,7 +349,7 @@ final class UsageViewModel: ObservableObject {
                     }
                     Task { [weak self] in
                         guard let self else { return }
-                        await self.waitForRecoveryFetch(for: provider)
+                        await self.waitForCopilotRecoveryFetch(for: provider)
                     }
                     return
                 }
@@ -293,10 +362,9 @@ final class UsageViewModel: ObservableObject {
         }
     }
 
-    private func handleLoginAndFetch(for provider: UsageProvider) async {
-        let store = webViewPool.getWebViewStore(for: provider)
-        // Verify login status before attempting API fetch.
-        let isLoggedIn = await checkLoginStatus(for: provider, using: store.webView)
+    private func handleCopilotLoginAndFetch(for provider: UsageProvider) async {
+        let webViewStore = webViewPool.getWebViewStore(for: provider)
+        let isLoggedIn = await checkLoginStatusViaWebView(for: provider, using: webViewStore.webView)
         guard isLoggedIn else {
             stateManager.setStatusMessage("status.loadingLogin".localized(), for: provider)
             if provider == selectedProvider {
@@ -304,30 +372,23 @@ final class UsageViewModel: ObservableObject {
             }
             return
         }
-
-        if !isUsageURL(store.webView.url, provider: provider) {
-            // Navigate to the usage page when logged in but not on target URL.
-            store.reloadFromOrigin()
+        if !isUsageURL(webViewStore.webView.url, provider: provider) {
+            webViewStore.reloadFromOrigin()
             return
         }
-
-        await refreshSnapshot(for: provider)
+        await refreshSnapshot(for: provider, isManual: true)
     }
 
-    private func checkLoginStatus(for provider: UsageProvider, using webView: WKWebView) async -> Bool {
-        // Delegate to provider-specific fetchers.
+    private func checkLoginStatusViaWebView(for provider: UsageProvider, using webView: WKWebView) async -> Bool {
         switch provider {
-        case .chatgptCodex:
-            return await codexFetcher.hasValidSession(using: webView)
-        case .claudeCode:
-            return await claudeFetcher.hasValidSession(using: webView)
         case .githubCopilot:
             return await copilotFetcher.hasValidSession(using: webView)
+        case .chatgptCodex, .claudeCode:
+            return true
         }
     }
 
     private func isUsageURL(_ url: URL?, provider: UsageProvider) -> Bool {
-        // Compare scheme/host/path to avoid false positives.
         guard let url else { return false }
         let usageURL = provider.usageURL
         return url.scheme == usageURL.scheme
@@ -336,43 +397,11 @@ final class UsageViewModel: ObservableObject {
     }
 
     private func consumeManualRefreshRequest(for provider: UsageProvider) -> Bool {
-        // Consume and clear manual refresh flag for the provider.
         manualRefreshRequests.remove(provider) != nil
     }
 
-    private func fetchSnapshot(for provider: UsageProvider, using webView: WKWebView) async throws -> UsageSnapshot {
-        // Delegate fetch to provider-specific fetchers.
-        switch provider {
-        case .chatgptCodex:
-            return try await codexFetcher.fetchUsageSnapshot(using: webView)
-        case .claudeCode:
-            return try await claudeFetcher.fetchUsageSnapshot(using: webView)
-        case .githubCopilot:
-            return try await copilotFetcher.fetchUsageSnapshot(using: webView)
-        }
-    }
-
     private func shouldDisableAutoRefresh(for provider: UsageProvider, error: Error) -> Bool {
-        // Disable auto-refresh only for authentication/organization issues.
         switch provider {
-        case .chatgptCodex:
-            guard let error = error as? CodexUsageFetcherError else { return false }
-            switch error {
-            case .scriptFailed(let message):
-                return isLoginRequiredMessage(message)
-            case .invalidResponse, .pageNotReady:
-                return false
-            }
-        case .claudeCode:
-            guard let error = error as? ClaudeUsageFetcherError else { return false }
-            switch error {
-            case .missingOrganization:
-                return true
-            case .scriptFailed(let message):
-                return isLoginRequiredMessage(message)
-            case .invalidResponse:
-                return false
-            }
         case .githubCopilot:
             guard let error = error as? CopilotUsageFetcherError else { return false }
             switch error {
@@ -381,11 +410,12 @@ final class UsageViewModel: ObservableObject {
             case .invalidResponse, .pageNotReady:
                 return false
             }
+        case .chatgptCodex, .claudeCode:
+            return (error as? UsageAuthError)?.requiresUserReauth ?? false
         }
     }
 
     private func isLoginRequiredMessage(_ message: String) -> Bool {
-        // Normalize and check for common auth-related error markers.
         let normalized = message.lowercased()
         return normalized.contains("missing access token")
             || normalized.contains("missing organization")
@@ -394,40 +424,22 @@ final class UsageViewModel: ObservableObject {
             || normalized.contains("http 403")
     }
 
-    /// ページ再ロード後、SPA の API コール完了を待ってから fetch を実行する。
-    /// handlePageReadyChange は autoRecoveryInFlight によりスキップされるため、ここで直接呼ぶ。
-    private func waitForRecoveryFetch(for provider: UsageProvider) async {
+    private func waitForCopilotRecoveryFetch(for provider: UsageProvider) async {
         let webViewStore = webViewPool.getWebViewStore(for: provider)
-        // ページロード完了を最大 15 秒待機
         let deadline = Date().addingTimeInterval(15)
         while !webViewStore.isPageReady && Date() < deadline {
             try? await Task.sleep(for: .milliseconds(500))
         }
         guard webViewStore.isPageReady else {
-            // タイムアウト: recovery フラグを解除して通常の auto refresh に戻す
             autoRecoveryInFlight.remove(provider)
             return
         }
-        // SPA が初期 API コールを performance.getEntriesByType("resource") に登録するまで待機
         try? await Task.sleep(for: .seconds(3))
-        await handleLoginAndFetch(for: provider)
-        // handleLoginAndFetch → refreshSnapshot が早期リターンした場合 (ページ未準備等) にフラグが残る可能性があるため解除
+        await handleCopilotLoginAndFetch(for: provider)
         autoRecoveryInFlight.remove(provider)
     }
 
-    /// missingOrganization エラー後の自動復旧用。stale な lastActiveOrg Cookie を削除し、
-    /// リロード後の JS が resource / HTML フォールバックで最新 orgId を取得できるようにする。
-    private func clearOrgIdCookie(for provider: UsageProvider) async {
-        guard provider == .claudeCode else { return }
-        let cookieStore = WKWebsiteDataStore.default().httpCookieStore
-        let cookies = await cookieStore.allCookies()
-        for cookie in cookies where cookie.name == "lastActiveOrg" {
-            await cookieStore.deleteCookie(cookie)
-        }
-    }
-
     private func canRedirectLogin(for provider: UsageProvider) -> Bool {
-        // Throttle redirects to avoid excessive reloads.
         let now = Date()
         let cooldown: TimeInterval = 5
         if let lastRedirectAt = lastLoginRedirectAt[provider],
@@ -440,8 +452,6 @@ final class UsageViewModel: ObservableObject {
 
     // MARK: - Copilot Billing
 
-    /// Fetches Copilot billing data and saves to token usage snapshot store.
-    /// Fire-and-forget: errors are logged but do not affect usage limits UI.
     private func fetchCopilotBilling(using webView: WKWebView) async {
         do {
             let snapshot = try await copilotBillingFetcher.fetchBillingSnapshot(using: webView)

--- a/AgentLimits/en.lproj/Localizable.strings
+++ b/AgentLimits/en.lproj/Localizable.strings
@@ -72,6 +72,19 @@
 "error.appGroupUnavailable" = "App Group unavailable. Check Signing & Capabilities.";
 "error.readFailed" = "Failed to read data";
 "error.decodeFailed" = "Failed to decode data";
+"error.codexAuthExpired" = "auth expired — codex login";
+"error.claudeReLogin" = "re-login: claude /login";
+"error.rateLimited" = "rate limited";
+
+/* Native auth panel (Codex/Claude — read credentials from disk/keychain) */
+"nativeAuth.loggedIn" = "%@ — signed in";
+"nativeAuth.notLoggedIn" = "%@ — not signed in";
+"nativeAuth.refresh" = "Refresh now";
+"nativeAuth.runCodexLogin" = "Run codex login";
+"nativeAuth.runClaudeLogin" = "Run claude /login";
+"nativeAuth.explanationCodex" = "Reads ~/.codex/auth.json. The Codex CLI rotates the token automatically; if it expires, run codex login.";
+"nativeAuth.explanationClaude" = "Reads the Claude Code-credentials keychain item written by claude /login. Tokens auto-refresh; if scope is insufficient, run claude /login.";
+"nativeAuth.waitingForLogin" = "Waiting for keychain update…";
 
 /* Relative Time */
 "time.minutesLater" = "In %d min";

--- a/AgentLimits/ja.lproj/Localizable.strings
+++ b/AgentLimits/ja.lproj/Localizable.strings
@@ -72,6 +72,19 @@
 "error.appGroupUnavailable" = "App Group が利用できません。Signing & Capabilities を確認してください。";
 "error.readFailed" = "データの読み込みに失敗しました";
 "error.decodeFailed" = "データの解析に失敗しました";
+"error.codexAuthExpired" = "認証が切れました — codex login を実行してください";
+"error.claudeReLogin" = "再ログインが必要です: claude /login";
+"error.rateLimited" = "レート制限中";
+
+/* Native auth panel (Codex/Claude — read credentials from disk/keychain) */
+"nativeAuth.loggedIn" = "%@ — サインイン済み";
+"nativeAuth.notLoggedIn" = "%@ — 未サインイン";
+"nativeAuth.refresh" = "今すぐ更新";
+"nativeAuth.runCodexLogin" = "codex login を実行";
+"nativeAuth.runClaudeLogin" = "claude /login を実行";
+"nativeAuth.explanationCodex" = "~/.codex/auth.json を読み込みます。トークンは Codex CLI が自動でローテーションします。期限切れの場合は codex login を実行してください。";
+"nativeAuth.explanationClaude" = "claude /login が書き込んだ Claude Code-credentials キーチェーン項目を読み込みます。トークンは自動更新されます。スコープ不足の場合は claude /login を再実行してください。";
+"nativeAuth.waitingForLogin" = "キーチェーン更新を待機中…";
 
 /* Relative Time */
 "time.minutesLater" = "%d分後";

--- a/AgentLimits/th.lproj/Localizable.strings
+++ b/AgentLimits/th.lproj/Localizable.strings
@@ -1,0 +1,220 @@
+/* Window */
+"window.settings.title" = "การตั้งค่า AgentLimits";
+
+/* Tabs */
+"tab.usage" = "การใช้งาน";
+"tab.wakeUp" = "ปลุก";
+"tab.notification" = "การแจ้งเตือน";
+"tab.pacemaker" = "Pacemaker";
+"tab.advanced" = "ขั้นสูง";
+
+/* Pacemaker */
+"pacemaker.description" = "ปรับแต่งการแสดงผล Pacemaker, เกณฑ์ และสี";
+
+/* Menu */
+"menu.openSettings" = "การตั้งค่า AgentLimits...";
+"settings.showMenuDashboard" = "แสดงแดชบอร์ดในเมนู";
+"menu.dashboard.remaining5h" = "🕔%@";
+"menu.dashboard.remainingHours" = "อีก %.1f ชม.";
+"menu.dashboard.remainingMinutes" = "อีก %d นาที";
+"menu.dashboard.weeklyReset" = "📅%@";
+"menu.dashboard.resetDaysLater" = "อีก %.1f วัน";
+"menu.dashboard.resetHoursLater" = "อีก %.1f ชม.";
+"menu.dashboard.resetMinutesLater" = "อีก %d นาที";
+"menu.dashboard.soon" = "เร็วๆ นี้";
+"menu.displayMode" = "โหมดแสดงผล";
+"menu.displayMode.used" = "อัตราการใช้งาน";
+"menu.displayMode.remaining" = "อัตราคงเหลือ";
+"menu.showPacemakerValue" = "แสดงตัวบ่งชี้ Pacemaker";
+"pacemaker.showRingWarningSegment" = "แสดงโซนเตือนของวงแหวน";
+"menu.about" = "เกี่ยวกับ AgentLimits";
+"menu.quit" = "ออกจากโปรแกรม";
+"menu.language" = "ภาษา";
+"menu.language.system" = "ค่าระบบ";
+
+/* ContentView */
+"content.login" = "เข้าสู่ระบบเพื่อดูอัตราการใช้งานปัจจุบัน";
+"content.usageLimit" = "ขีดจำกัดการใช้งาน";
+"content.autoRefresh" = "บริการที่ล็อกอินแล้วจะอัปเดตอัตโนมัติทุก %d นาที";
+"refreshInterval.label" = "ช่วงเวลาอัปเดต";
+"refreshInterval.minutesFormat" = "%d นาที";
+"content.refreshNow" = "อัปเดตทันที";
+"content.clearData" = "ล้างข้อมูล";
+"content.clearDataConfirmTitle" = "ล้างข้อมูล";
+"content.clearDataConfirmMessage" = "การดำเนินการนี้จะลบข้อมูลล็อกอินและข้อมูลเว็บไซต์ของเบราว์เซอร์ที่ฝังไว้";
+"content.clearDataConfirmAction" = "ล้าง";
+"content.clearDataCancel" = "ยกเลิก";
+"content.provider" = "บริการ";
+"content.usageSummary" = "สถานะ";
+"content.5hours" = "5 ชั่วโมง";
+"content.week" = "สัปดาห์";
+"usage.updated" = "อัปเดตเมื่อ: ";
+"content.notFetched" = "ยังไม่ได้ดึงข้อมูล กรุณาเข้าสู่ระบบด้านล่าง";
+"content.reset" = "รีเซ็ต:";
+"content.popupClose" = "ปิด";
+"settings.showInMenuBar" = "แสดงในแถบเมนู";
+
+/* Display Mode */
+"displayMode.used" = "อัตราการใช้งาน";
+"displayMode.remaining" = "อัตราคงเหลือ";
+"displayMode.usedWithPacemaker" = "การใช้งาน + Pacemaker";
+
+/* Status */
+"status.notFetched" = "ยังไม่ได้ดึงข้อมูล";
+"status.loadingLogin" = "กำลังโหลดหน้าล็อกอิน...";
+"status.updated" = "อัปเดตแล้ว";
+
+/* Errors */
+"error.fetchFailed" = "ดึงข้อมูลไม่สำเร็จ: %@";
+"error.parseFailed" = "ไม่สามารถวิเคราะห์ผลลัพธ์ได้";
+"error.loginNotLoaded" = "ยังโหลดหน้าล็อกอินไม่เสร็จ";
+"error.missingOrg" = "ไม่สามารถดึง Organization ID ได้ กรุณาเปิดหน้าการใช้งานใหม่";
+"error.appGroupUnavailable" = "ไม่สามารถใช้ App Group ได้ กรุณาตรวจสอบ Signing & Capabilities";
+"error.readFailed" = "อ่านข้อมูลไม่สำเร็จ";
+"error.decodeFailed" = "ถอดรหัสข้อมูลไม่สำเร็จ";
+"error.codexAuthExpired" = "การพิสูจน์ตัวตนหมดอายุ — โปรดรัน codex login";
+"error.claudeReLogin" = "โปรดล็อกอินใหม่: claude /login";
+"error.rateLimited" = "ถูกจำกัดอัตราการใช้งาน";
+
+/* Native auth panel (Codex/Claude — read credentials from disk/keychain) */
+"nativeAuth.loggedIn" = "%@ — เข้าสู่ระบบแล้ว";
+"nativeAuth.notLoggedIn" = "%@ — ยังไม่ได้เข้าสู่ระบบ";
+"nativeAuth.refresh" = "อัปเดตทันที";
+"nativeAuth.runCodexLogin" = "รัน codex login";
+"nativeAuth.runClaudeLogin" = "รัน claude /login";
+"nativeAuth.explanationCodex" = "อ่านไฟล์ ~/.codex/auth.json โดย Codex CLI จะหมุนเวียนโทเค็นให้อัตโนมัติ หากหมดอายุให้รัน codex login";
+"nativeAuth.explanationClaude" = "อ่านรายการคีย์เชน Claude Code-credentials ที่ claude /login เขียนไว้ โทเค็นจะรีเฟรชอัตโนมัติ หาก scope ไม่เพียงพอให้รัน claude /login อีกครั้ง";
+"nativeAuth.waitingForLogin" = "กำลังรอการอัปเดตคีย์เชน…";
+
+/* Relative Time */
+"time.minutesLater" = "อีก %d นาที";
+"time.hoursLater" = "อีก %d ชั่วโมง";
+"time.daysLater" = "อีก %d วัน";
+
+/* Wake Up */
+"menu.wakeUp" = "ปลุก";
+"menu.wakeUpNow" = " - รันทันที";
+"wakeUp.title" = "ตารางเวลาปลุก";
+"wakeUp.description" = "เรียก CLI ตามเวลาที่กำหนดเพื่อเริ่มเซสชัน 5 ชั่วโมง";
+"wakeUp.provider" = "บริการ";
+"wakeUp.schedule" = "ตารางเวลา";
+"wakeUp.enabled" = "เปิดใช้งานตารางเวลา";
+"wakeUp.selectHours" = "เลือกชั่วโมงที่จะรัน (เลือกได้หลายค่า)";
+"wakeUp.selectedHours" = "ที่เลือก:";
+"wakeUp.noHoursSelected" = "ไม่มี";
+"wakeUp.hoursSelected" = "ชั่วโมงที่เลือก";
+"wakeUp.testNow" = "ทดสอบทันที";
+"wakeUp.command" = "คำสั่ง";
+"wakeUp.additionalArgs" = "พารามิเตอร์เพิ่มเติม";
+"wakeUp.additionalArgsPlaceholder" = "เช่น --model=\"<<model-name>>\"";
+"wakeUp.status" = "สถานะ";
+"wakeUp.notScheduled" = "ยังไม่ได้ตั้งเวลา";
+"wakeUp.lastResult" = "ผลลัพธ์ล่าสุด:";
+"wakeUp.success" = "สำเร็จ";
+"wakeUp.startAtLogin" = "เริ่มแอปเมื่อเข้าสู่ระบบ";
+
+/* Login Item */
+"loginItem.requiresApproval" = "ต้องอนุญาตใน System Settings";
+"loginItem.notFound" = "ไม่พบรายการเริ่มต้นอัตโนมัติ";
+
+/* Threshold Notification */
+"notification.title" = "การแจ้งเตือนเกณฑ์อัตราการใช้งาน";
+"notification.description" = "ตั้งค่าเกณฑ์การแจ้งเตือนและสีของอัตราการใช้งาน";
+"notification.provider" = "บริการ";
+"notification.colors" = "สี";
+"notification.authorization" = "ต้องการสิทธิ์การแจ้งเตือน";
+"notification.requestAuth" = "ขอสิทธิ์";
+"notification.primaryWindow" = "ขีดจำกัด 5 ชั่วโมง";
+"notification.secondaryWindow" = "ขีดจำกัดรายสัปดาห์";
+"notification.enabled" = "เปิดใช้งานการแจ้งเตือนเกณฑ์";
+"notification.warning" = "ระดับเตือน";
+"notification.danger" = "ระดับอันตราย";
+"notification.resetDefaults" = "รีเซ็ตเป็นค่าเริ่มต้น";
+"notification.alertTitleWarning" = "%@ เตือนอัตราการใช้งาน";
+"notification.alertTitleDanger" = "%@ อัตราการใช้งานอันตราย";
+"notification.alertBody5h" = "ใช้งานในรอบ 5 ชั่วโมงถึง %d%% แล้ว";
+"notification.alertBodyWeek" = "ใช้งานในรอบสัปดาห์ถึง %d%% แล้ว";
+"notification.alertBodyMonth" = "ใช้งานในรอบเดือนถึง %d%% แล้ว";
+"notification.monthlyWindow" = "ขีดจำกัดรายเดือน";
+
+/* ccusage */
+"tab.ccusage" = "ccusage";
+"ccusage.title" = "ติดตามการใช้งานโทเค็น (ccusage)";
+"ccusage.description" = "ดึงข้อมูลการใช้งานโทเค็นและค่าใช้จ่ายด้วย ccusage CLI";
+"ccusage.settings" = "การตั้งค่า";
+"ccusage.enabled" = "เปิดใช้งานการดึงข้อมูลตามรอบ";
+"ccusage.command" = "คำสั่ง";
+"ccusage.additionalArgs" = "พารามิเตอร์เพิ่มเติม";
+"ccusage.additionalArgsPlaceholder" = "เช่น --timezone <<timezone>>";
+"ccusage.testNow" = "ทดสอบทันที";
+"ccusage.status" = "สถานะ";
+"ccusage.lastResult" = "ผลลัพธ์ล่าสุด:";
+"tokenUsage.notFetched" = "ยังไม่ได้ดึงข้อมูล";
+"tokenUsage.updated" = "อัปเดตเมื่อ: ";
+"ccusage.provider" = "บริการ";
+"ccusage.disabled" = "ปิดใช้งาน";
+"ccusage.credits.title" = "เครดิต";
+"ccusage.credits.body" = "ขอบคุณเป็นพิเศษถึง ryoppippi ผู้สร้าง ccusage";
+"ccusage.credits.site" = "เว็บไซต์ ccusage";
+"ccusage.credits.repo" = "GitHub: ryoppippi/ccusage";
+"ccusage.copilot.autoFetchNote" = "ดึงข้อมูลอัตโนมัติพร้อมกับการใช้งาน Copilot";
+
+/* Advanced Settings */
+"advancedSettings.title" = "การตั้งค่าขั้นสูง";
+"advancedSettings.description" = "ปรับแต่งพาธของ CLI, สคริปต์ และการทำงานของวิดเจ็ต";
+"cliPaths.sectionTitle" = "พาธคำสั่ง CLI";
+"cliPaths.codex" = "พาธ codex";
+"cliPaths.claude" = "พาธ claude";
+"cliPaths.npx" = "พาธ npx";
+"cliPaths.codex.placeholder" = "เช่น /opt/homebrew/bin/codex";
+"cliPaths.claude.placeholder" = "เช่น /opt/homebrew/bin/claude";
+"cliPaths.npx.placeholder" = "เช่น /opt/homebrew/bin/npx";
+"cliPaths.note" = "การเปลี่ยนแปลงจะมีผลเมื่อรัน CLI ครั้งถัดไป";
+"cliPaths.resolvedLabel" = "ที่พบ:";
+"cliPaths.notFound" = "ไม่พบ";
+
+/* CLI Colors */
+"cliColors.donut" = "สีของกราฟโดนัท";
+"cliColors.donutUseStatus" = "ใช้สีตามอัตราการใช้งาน";
+"cliColors.green" = "อัตราการใช้งาน (ปกติ)";
+"cliColors.orange" = "อัตราการใช้งาน (เตือน)";
+"cliColors.red" = "อัตราการใช้งาน (อันตราย)";
+"cliColors.reset" = "รีเซ็ตเป็นค่าเริ่มต้น";
+
+/* Pacemaker Colors */
+"cliColors.pacemaker" = "การตั้งค่าสี";
+"cliColors.pacemakerRing" = "กราฟโดนัท";
+"cliColors.pacemakerOrange" = "เกินจังหวะ (เตือน)";
+"cliColors.pacemakerRed" = "เกินจังหวะ (อันตราย)";
+
+/* Scripts */
+"scripts.title" = "สคริปต์ที่มาพร้อมแอป";
+"scripts.claudeCode.title" = "สคริปต์แสดงสถานะของ Claude Code";
+"scripts.claudeCode.note" = "ใช้สคริปต์นี้กับฟีเจอร์ status line ของ Claude Code เพื่อแสดงอัตราการใช้งาน";
+"scripts.copy" = "คัดลอกพาธ";
+"scripts.copied" = "คัดลอกแล้ว!";
+"scripts.notFound" = "ไม่พบสคริปต์ในแอป";
+
+/* Widget Tap Action */
+"widgetTapAction.title" = "การแตะวิดเจ็ต";
+"widgetTapAction.openWebsite" = "เปิดเว็บไซต์";
+"widgetTapAction.refreshData" = "อัปเดตข้อมูล";
+"widgetTapAction.note" = "เลือกการทำงานเมื่อแตะวิดเจ็ต";
+
+/* Pacemaker Thresholds */
+"notification.pacemakerThresholds" = "เกณฑ์ Pacemaker";
+"notification.pacemakerThresholds.description" = "ตั้งเกณฑ์เตือนและอันตรายเมื่อใช้งานเกินจังหวะ (เทียบเป็น %)";
+"notification.pacemakerThresholds.warning" = "เตือน";
+"notification.pacemakerThresholds.danger" = "อันตราย";
+"content.month" = "รายเดือน";
+
+/* Update */
+"menu.checkForUpdates" = "ตรวจหาการอัปเดต...";
+"tab.update" = "อัปเดต";
+"update.currentVersion" = "เวอร์ชันปัจจุบัน";
+"update.lastChecked" = "ตรวจสอบล่าสุด";
+"update.checkNow" = "ตรวจหาการอัปเดตทันที";
+"update.automaticChecks" = "ตรวจหาการอัปเดตอัตโนมัติ";
+"update.releasesPage" = "ดูรุ่นทั้งหมด";
+"update.neverChecked" = "ยังไม่เคยตรวจ";
+"settings.providerOrder" = "ลำดับการแสดงผล";

--- a/AgentLimitsShared/UsageModels.swift
+++ b/AgentLimitsShared/UsageModels.swift
@@ -792,6 +792,23 @@ extension UsageWindow {
     }
 }
 
+/// Paid-overage block returned by Claude's `/api/oauth/usage` endpoint.
+/// Populated only when the user has explicitly enabled paid overage —
+/// nil otherwise. This is the closest thing to a real numeric cap either
+/// provider exposes.
+struct ExtraUsageInfo: Codable, Equatable {
+    /// True when the account has paid overage turned on.
+    let isEnabled: Bool
+    /// Monthly cap in `currency`, if any.
+    let monthlyLimit: Double?
+    /// Credits used so far in this billing window, in `currency`.
+    let usedCredits: Double?
+    /// 0-100 percentage of monthly_limit consumed, when both numbers are present.
+    let utilization: Double?
+    /// ISO 4217 currency code (e.g. "USD") — nil when overage is disabled.
+    let currency: String?
+}
+
 /// A snapshot of usage data for a provider at a specific point in time
 struct UsageSnapshot: Codable, SnapshotData {
     let provider: UsageProvider
@@ -803,19 +820,34 @@ struct UsageSnapshot: Codable, SnapshotData {
     let secondaryWindow: UsageWindow?
     /// Display mode used by UI when rendering this snapshot
     let displayMode: UsageDisplayModeRaw
+    /// Subscription plan ("free", "plus", "max", …) when the provider exposes it.
+    /// Codex provides this via `rate_limit.plan_type`; Claude provides it only
+    /// in the keychain payload's `subscriptionType` (not in the usage response).
+    let planType: String?
+    /// True when the provider has signalled the cap is reached (Codex
+    /// `rate_limit.limit_reached`). Propagated onto both windows for badge UI.
+    let limitReached: Bool
+    /// Claude paid-overage cap, when present. nil for Codex/Copilot.
+    let extraUsage: ExtraUsageInfo?
 
     init(
         provider: UsageProvider,
         fetchedAt: Date,
         primaryWindow: UsageWindow?,
         secondaryWindow: UsageWindow?,
-        displayMode: UsageDisplayModeRaw = .used
+        displayMode: UsageDisplayModeRaw = .used,
+        planType: String? = nil,
+        limitReached: Bool = false,
+        extraUsage: ExtraUsageInfo? = nil
     ) {
         self.provider = provider
         self.fetchedAt = fetchedAt
         self.primaryWindow = primaryWindow
         self.secondaryWindow = secondaryWindow
         self.displayMode = displayMode
+        self.planType = planType
+        self.limitReached = limitReached
+        self.extraUsage = extraUsage
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -824,6 +856,9 @@ struct UsageSnapshot: Codable, SnapshotData {
         case primaryWindow
         case secondaryWindow
         case displayMode
+        case planType
+        case limitReached
+        case extraUsage
     }
 
     init(from decoder: Decoder) throws {
@@ -833,6 +868,10 @@ struct UsageSnapshot: Codable, SnapshotData {
         primaryWindow = try container.decodeIfPresent(UsageWindow.self, forKey: .primaryWindow)
         secondaryWindow = try container.decodeIfPresent(UsageWindow.self, forKey: .secondaryWindow)
         displayMode = try container.decodeIfPresent(UsageDisplayModeRaw.self, forKey: .displayMode) ?? .used
+        // Backward-compatible: old snapshots predate these fields.
+        planType = try container.decodeIfPresent(String.self, forKey: .planType)
+        limitReached = try container.decodeIfPresent(Bool.self, forKey: .limitReached) ?? false
+        extraUsage = try container.decodeIfPresent(ExtraUsageInfo.self, forKey: .extraUsage)
     }
 }
 

--- a/AgentLimitsWidget/th.lproj/Localizable.strings
+++ b/AgentLimitsWidget/th.lproj/Localizable.strings
@@ -1,0 +1,26 @@
+/* Widget */
+"widget.description" = "แสดงอัตราการใช้งานในรอบ 5 ชั่วโมงและรายสัปดาห์";
+"widget.notFetched" = "ยังไม่ได้ดึงข้อมูล";
+"widget.pleaseLogin" = "กรุณาเข้าสู่ระบบในแอป";
+"widget.5hourLimit" = "ขีดจำกัด 5 ชั่วโมง";
+"widget.weeklyLimit" = "ขีดจำกัดรายสัปดาห์";
+"widget.reset" = "รีเซ็ตเมื่อ";
+"widget.updatedAt" = "อัปเดตเมื่อ:";
+"error.appGroupUnavailable" = "ไม่สามารถใช้ App Group ได้ กรุณาตรวจสอบ Signing & Capabilities";
+"error.readFailed" = "อ่านข้อมูลไม่สำเร็จ";
+"error.decodeFailed" = "ถอดรหัสข้อมูลไม่สำเร็จ";
+
+/* Reset Time */
+"time.minutesLater" = "อีก %d นาที";
+"time.hoursLater" = "อีก %@ ชั่วโมง";
+"time.daysLater" = "อีก %d วัน";
+
+/* Token Usage Widget (ccusage) */
+"widget.tokenUsage.today" = "วันนี้";
+"widget.tokenUsage.thisWeek" = "สัปดาห์นี้";
+"widget.tokenUsage.thisMonth" = "เดือนนี้";
+"widget.tokenUsageDescription" = "แสดงการใช้งานโทเค็นและค่าใช้จ่าย";
+"widget.pleaseOpenApp" = "กรุณาเปิดแอป";
+"widget.monthlyLimit" = "ขีดจำกัดรายเดือน";
+"widget.premiumRequests" = "คำขอแบบพรีเมียม";
+"widget.copilotBillingDescription" = "แสดงการใช้งานและค่าใช้จ่ายของ Copilot";


### PR DESCRIPTION
## Summary

Migrates **Codex** and **Claude Code** usage retrieval from in-app WKWebView JavaScript injection to native HTTPS calls that reuse the credentials each provider's CLI already writes to disk / keychain — matching the approach in [codex-island](https://github.com/ericjypark/codex-island). No API-key paste flow. **Copilot is unchanged** (its billing endpoint still requires a logged-in browser session).

### What changes per provider

**Codex (`chatgpt.com`)** — reads `tokens.access_token` from `~/.codex/auth.json`, calls `GET https://chatgpt.com/backend-api/wham/usage` with `Authorization: Bearer …`. On HTTP 401 surfaces `auth expired — codex login`. Propagates `rate_limit.limit_reached` and `plan_type` into the snapshot.

**Claude (`anthropic.com`)** — calls `GET https://api.anthropic.com/api/oauth/usage` with all 5 required headers (`Authorization`, `anthropic-beta: oauth-2025-04-20`, `User-Agent: claude-code/<version>`, `Accept`, `Content-Type`). Token resolution order: `CLAUDE_CODE_OAUTH_TOKEN` env var → `Claude Code-credentials` keychain item written by `claude /login` (read via `/usr/bin/security` invoked with argv only — no shell, no quoting hazards). On HTTP 401 refreshes via `POST https://platform.claude.com/v1/oauth/token` and **writes the rotated access+refresh pair back to the keychain atomically** — both tokens rotate on every refresh, and skipping the write-back desyncs Claude Code itself.

### Status-code matrix (Claude)

| Code | Action |
|------|--------|
| 200 + `error.type == "rate_limit_error"` | surface `rate limited` (Anthropic sometimes returns 200 for rate-limit) |
| 200 | parse |
| 401 | refresh once + retry; persistent 401 → `re-login: claude /login` |
| 403 (scope insufficient, missing `user:profile`) | `re-login: claude /login` — refresh re-issues same scope set |
| 429 | `rate limited` |

### Other behavior

- **Re-auth UX**: Settings panel now shows a native auth status card (plan badge from `subscriptionType`, last-fetch text, "Run codex login" / "Run claude /login" + "Refresh now" buttons). The CLI is detached-spawned via the codex-island path probe list (`/opt/homebrew/bin`, `/usr/local/bin`, `~/.bun/bin`, `~/.npm-global/bin`, `~/.local/bin`, highest `~/.nvm/versions/node/<v>/bin`) since GUI apps get a stripped PATH from LaunchServices.
- **5-min minimum poll** for Codex/Claude — Anthropic rate-limits aggressively per token and sub-5-min polling burns the user's daily quota.
- **Schema additions** (backward-compatible): `UsageSnapshot` gains optional `planType`, `limitReached`, `extraUsage` (`ExtraUsageInfo` for paid-overage cap). Existing snapshots still decode via `decodeIfPresent`.
- **Thai (`th`) localization** added for app + widget targets.

### Files

**New** (`AgentLimits/Usage/Native/`):
- `UsageAuthError.swift` — error sentinels matching codex-island wording
- `NativeUsageHTTPClient.swift` — URLSession wrapper that returns the raw `HTTPURLResponse` so callers can status-branch
- `CodexAuthStore.swift`, `ClaudeKeychainStore.swift`, `ClaudeOAuthClient.swift`, `ClaudeOAuthConfig.swift`, `ClaudeCLILocator.swift`

**Rewritten**: `CodexUsageFetcher.swift`, `ClaudeUsageFetcher.swift`, `UsageViewModel.swift`, `ContentView.swift`

**Extended**: `AgentLimitsShared/UsageModels.swift` (snapshot schema), `en.lproj` + `ja.lproj` strings; new `th.lproj` for both targets.

## Test plan

- [ ] `xcodebuild -scheme AgentLimits -destination 'platform=macOS' build` — passes
- [ ] Codex: with `codex login` complete, snapshot writes within 1 min of launch
- [ ] Claude: with `claude /login` complete, Settings → Claude Code → Refresh now → snapshot writes; subsequent auto-polls every ≥5 min
- [ ] Claude 401 path: invalidate the keychain access token, trigger fetch → refresh succeeds, rotated pair written back, fetch retries OK
- [ ] Claude 403 path: token missing `user:profile` scope → UI shows `re-login: claude /login`, CLI re-launches, keychain updates picked up on next poll
- [ ] Thai locale: menu bar → Language → ภาษาไทย → all strings render
- [ ] Old WebView-format snapshot files still load (backward compatibility via `decodeIfPresent`)